### PR TITLE
Update Unity project settings to be able to build the UWP solution for HoloLens

### DIFF
--- a/src/SpectatorView.Unity/.gitignore
+++ b/src/SpectatorView.Unity/.gitignore
@@ -61,6 +61,19 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+# Unity UWP Output
+UWP/
+
+# Certificates
+*.cert
+*.privkey
+*.pfx
+*.pfx.meta
+
+# Custom - Generated Asset Caches
+Assets/Generated.StateSynchronization.AssetCaches.meta
+Assets/Generated.StateSynchronization.AssetCaches/
+
 # Custom - External Unity Packages
 Assets/AzureSpatialAnchorsPlugin.meta
 Assets/AzureSpatialAnchorsPlugin/

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.ArUco.HoloLens.unity
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.ArUco.HoloLens.unity
@@ -304,7 +304,6 @@ GameObject:
   - component: {fileID: 1869681821}
   - component: {fileID: 1869681820}
   - component: {fileID: 1869681824}
-  - component: {fileID: 1869681823}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -376,29 +375,6 @@ Transform:
   m_Father: {fileID: 1855549804}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1869681823
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1869681819}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf98dd1206224111a38765365e98e207, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  setCursorInvisibleWhenFocusLocked: 1
-  maxGazeCollisionDistance: 10
-  raycastLayerMasks:
-  - serializedVersion: 2
-    m_Bits: 4294967291
-  stabilizer:
-    storedStabilitySamples: 60
-  gazeTransform: {fileID: 0}
-  minHeadVelocityThreshold: 0.5
-  maxHeadVelocityThreshold: 2
-  useEyeTracking: 0
 --- !u!114 &1869681824
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/src/SpectatorView.Unity/Packages/manifest.json
+++ b/src/SpectatorView.Unity/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.package-manager-ui": "2.0.7",
     "com.unity.purchasing": "2.0.3",
     "com.unity.textmeshpro": "1.3.0",
+    "com.unity.xr.windowsmr.metro": "1.0.12",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/src/SpectatorView.Unity/ProjectSettings/EditorBuildSettings.asset
+++ b/src/SpectatorView.Unity/ProjectSettings/EditorBuildSettings.asset
@@ -4,8 +4,5 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes:
-  - enabled: 1
-    path: Assets/SpectatorView/Scenes/SpectatorView.ArUco.HoloLens.unity
-    guid: aaaef5009f203534696f812a2010313e
+  m_Scenes: []
   m_configObjects: {}

--- a/src/SpectatorView.Unity/ProjectSettings/EditorBuildSettings.asset
+++ b/src/SpectatorView.Unity/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/SpectatorView/Scenes/SpectatorView.ArUco.HoloLens.unity
+    guid: aaaef5009f203534696f812a2010313e
   m_configObjects: {}

--- a/src/SpectatorView.Unity/ProjectSettings/GraphicsSettings.asset
+++ b/src/SpectatorView.Unity/ProjectSettings/GraphicsSettings.asset
@@ -36,6 +36,8 @@ GraphicsSettings:
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10783, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/src/SpectatorView.Unity/ProjectSettings/ProjectSettings.asset
+++ b/src/SpectatorView.Unity/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: DefaultCompany
-  productName: SpectatorView.Unity
+  productName: SpectatorViewUnity
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -294,6 +294,10 @@ PlayerSettings:
     m_Devices:
     - Oculus
     - OpenVR
+  - m_BuildTarget: Metro
+    m_Enabled: 1
+    m_Devices:
+    - WindowsMR
   m_BuildTargetEnableVuforiaSettings: []
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
@@ -529,7 +533,8 @@ PlayerSettings:
   webGLThreadsSupport: 0
   scriptingDefineSymbols: {}
   platformArchitecture: {}
-  scriptingBackend: {}
+  scriptingBackend:
+    Metro: 2
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
@@ -539,16 +544,17 @@ PlayerSettings:
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
-  metroPackageName: Template_3D
-  metroPackageVersion: 
-  metroCertificatePath: 
+  metroPackageName: SpectatorView.Unity
+  metroPackageVersion: 1.0.0.0
+  metroCertificatePath: Assets\WSATestCertificate.pfx
   metroCertificatePassword: 
-  metroCertificateSubject: 
-  metroCertificateIssuer: 
-  metroCertificateNotAfter: 0000000000000000
-  metroApplicationDescription: Template_3D
+  metroCertificateSubject: DefaultCompany
+  metroCertificateIssuer: DefaultCompany
+  metroCertificateNotAfter: 007a5ac41245d601
+  metroApplicationDescription: Mixed-reality spectator view for third person perspective
+    viewing of mixed-reality applications
   wsaImages: {}
-  metroTileShortName: 
+  metroTileShortName: SpectatorView.Unity
   metroTileShowName: 0
   metroMediumTileShowName: 0
   metroLargeTileShowName: 0
@@ -561,8 +567,53 @@ PlayerSettings:
   metroSplashScreenBackgroundColor: {r: 0.12941177, g: 0.17254902, b: 0.21568628,
     a: 1}
   metroSplashScreenUseBackgroundColor: 0
-  platformCapabilities: {}
-  metroTargetDeviceFamilies: {}
+  platformCapabilities:
+    WindowsStoreApps:
+      AllJoyn: False
+      Appointments: False
+      BackgroundMediaPlayback: False
+      BlockedChatMessages: False
+      Bluetooth: False
+      Chat: False
+      CodeGeneration: False
+      Contacts: False
+      EnterpriseAuthentication: False
+      HumanInterfaceDevice: False
+      InputInjectionBrokered: False
+      InternetClient: True
+      InternetClientServer: True
+      Location: False
+      LowLevelDevices: False
+      Microphone: True
+      MusicLibrary: False
+      Objects3D: False
+      OfflineMapsManagement: False
+      PhoneCall: False
+      PhoneCallHistoryPublic: False
+      PicturesLibrary: True
+      PointOfService: False
+      PrivateNetworkClientServer: True
+      Proximity: False
+      RecordedCallsFolder: False
+      RemoteSystem: False
+      RemovableStorage: False
+      SharedUserCertificates: False
+      SpatialPerception: True
+      SystemManagement: False
+      UserAccountInformation: False
+      UserDataTasks: False
+      UserNotificationListener: False
+      VideosLibrary: False
+      VoipCall: False
+      WebCam: True
+  metroTargetDeviceFamilies:
+    Desktop: False
+    Holographic: False
+    IoT: False
+    IoTHeadless: False
+    Mobile: False
+    Team: False
+    Xbox: False
   metroFTAName: 
   metroFTAFileTypes: []
   metroProtocolName: 

--- a/src/SpectatorView.Unity/ProjectSettings/UnityConnectSettings.asset
+++ b/src/SpectatorView.Unity/ProjectSettings/UnityConnectSettings.asset
@@ -4,7 +4,7 @@
 UnityConnectSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 1
-  m_Enabled: 0
+  m_Enabled: 1
   m_TestMode: 0
   m_EventOldUrl: https://api.uca.cloud.unity3d.com/v1/events
   m_EventUrl: https://cdp.cloud.unity3d.com/v1/events


### PR DESCRIPTION
Main changes were:
1. gitignore updates to mask out generated content that results from updating asset caches and building the UWP solution
2. Updating the capabilities and package name (specifically the name of the project can't end with .Unity, as this causes a namespace conflict in the generated App.cs in the UWP solution)
3. Removing a missing GazeProvider component in SpectatorView.ArUco.HoloLens