### PR TITLE
Fix texture sampling for RGBtoYUV

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/RGBToYUV.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/RGBToYUV.shader
@@ -53,6 +53,7 @@ Shader "SV/RGBToYUV"
                 float2 offset = float2(0, 0);
                 if (uv.x < 0.0f)
                 {
+					offset.x += 1.0;
                     offset.y = (0.5 / _Height);
                 }
                 else

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/RGBToYUV.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/RGBToYUV.shader
@@ -53,7 +53,7 @@ Shader "SV/RGBToYUV"
                 float2 offset = float2(0, 0);
                 if (uv.x < 0.0f)
                 {
-					offset.x += 1.0;
+                    offset.x += 1.0;
                     offset.y = (0.5 / _Height);
                 }
                 else

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -212,8 +212,6 @@ namespace Microsoft.MixedReality.SpectatorView
             colorRGBTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
             alphaTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
             compositeTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
-            // this is needed for the shader that converts back to YUV
-            compositeTexture.wrapMode = TextureWrapMode.Repeat;
 
             if (supersampleBuffers.Length > 0)
             {


### PR DESCRIPTION
The texture sampling in RGBtoYUV was working because the source texture's wrapMode was set to Repeat. However, in Unity 2018 that no longer seems to behave as expected for negative values of 'u'. This change fixes the issue in the shader by ensuring 'u' values are kept to the (0, 1) range rather than relying on the Repeat behavior.