### PR TITLE
Fix arkit camera prefab

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.iOS.unity
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.iOS.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074, b: 0.35872698, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -268,6 +268,11 @@ PrefabInstance:
       propertyPath: m_camera
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 898838627460868331, guid: ef500abe56e2fdb4086db81263f1c873,
+        type: 3}
+      propertyPath: m_ClearMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: f1d9352050a75486f878ab19fa578f16, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef500abe56e2fdb4086db81263f1c873, type: 3}
 --- !u!4 &1494373462 stripped


### PR DESCRIPTION
The YUVMaterial defined for Unity AR Video got dropped in the recent prefab definition.