### PR TITLE
Make the components needed to perform dynamic object synchronization public so that they can be extended

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/DynamicGameObjectHierarchy/DynamicGameObjectHierarchyBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/DynamicGameObjectHierarchy/DynamicGameObjectHierarchyBroadcaster.cs
@@ -7,7 +7,14 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.SpectatorView
 {
-    internal abstract class DynamicGameObjectHierarchyBroadcaster<TComponentService> : ComponentBroadcaster<TComponentService, byte> where TComponentService : Singleton<TComponentService>, IComponentBroadcasterService
+    /// <summary>
+    /// A ComponentBroadcaster that allows instantiating a custom child hierarchy for the remote DynamicGameObjectHierarchyObserver.
+    /// The corresponding DynamicGameObjectHierarchyObserver is responsible for creating an initially-identical child
+    /// hierarchy. Once both devices have created the same initial hierarchy, the hierarchies are bound together
+    /// and state synchronization is initialized for all of the GameObjects within that hierarchy.
+    /// </summary>
+    /// <typeparam name="TComponentService">The IComponentBroadcasterService responsible for network communication for this ComponentBroadcaster.</typeparam>
+    public abstract class DynamicGameObjectHierarchyBroadcaster<TComponentService> : ComponentBroadcaster<TComponentService, byte> where TComponentService : Singleton<TComponentService>, IComponentBroadcasterService
     {
         private GameObject dynamicObject;
         private Dictionary<SocketEndpoint, PerConnectionInstantiationState> perConnectionInstantiationState = new Dictionary<SocketEndpoint, PerConnectionInstantiationState>();
@@ -27,6 +34,9 @@ namespace Microsoft.MixedReality.SpectatorView
             public const byte ObserverHierarchyBound = 0x3;
         }
 
+        /// <summary>
+        /// Gets or sets the locally-created dynamic GameObject hierarchy root.
+        /// </summary>
         protected GameObject DynamicObject
         {
             get { return dynamicObject; }
@@ -160,8 +170,6 @@ namespace Microsoft.MixedReality.SpectatorView
 
         protected void SendInstantiationRequest()
         {
-            DynamicObject = null;
-
             foreach (KeyValuePair<SocketEndpoint, PerConnectionInstantiationState> state in perConnectionInstantiationState)
             {
                 TransformBroadcaster.BlockedConnections.Add(state.Key);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/DynamicGameObjectHierarchy/DynamicGameObjectHierarchyObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/DynamicGameObjectHierarchy/DynamicGameObjectHierarchyObserver.cs
@@ -6,7 +6,14 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.SpectatorView
 {
-    internal abstract class DynamicGameObjectHierarchyObserver<TComponentService> : MonoBehaviour, IComponentObserver where TComponentService : Singleton<TComponentService>, IComponentBroadcasterService
+    /// <summary>
+    /// A ComponentObserver that allows instantiating a custom child hierarchy for the remote DynamicGameObjectHierarchyBroadcaster.
+    /// The corresponding DynamicGameObjectHierarchyBroadcaster is responsible for creating an initially-identical child
+    /// hierarchy. Once both devices have created the same initial hierarchy, the hierarchies are bound together
+    /// and state synchronization is initialized for all of the GameObjects within that hierarchy.
+    /// </summary>
+    /// <typeparam name="TComponentService">The IComponentBroadcasterService responsible for network communication for this IComponentObserver.</typeparam>
+    public abstract class DynamicGameObjectHierarchyObserver<TComponentService> : MonoBehaviour, IComponentObserver where TComponentService : Singleton<TComponentService>, IComponentBroadcasterService
     {
         private GameObject dynamicObject;
 
@@ -48,7 +55,6 @@ namespace Microsoft.MixedReality.SpectatorView
         public void Read(SocketEndpoint sendingEndpoint, BinaryReader message)
         {
             byte changeType = message.ReadByte();
-
             Read(sendingEndpoint, message, changeType);
         }
 


### PR DESCRIPTION
I ported an internal test scene to use the new MR-SpectatorView, and found that these types need to be public in order to derive from them and synchronized dynamic GameObject hierarchies (where, for example, a dynamic model is constructed on both ends of the connection and then synchronization starts). I also discovered a bug in the base class (setting the DynamicObject to null should never happen in the base class).