### PR TITLE
Fix qr code marker detection to initialize correctly on a clean install

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/QRCode/QRCodeMarkerDetector.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/QRCode/QRCodeMarkerDetector.cs
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 _qrCodesManager.QRCodeAdded += QRCodeAdded;
                 _qrCodesManager.QRCodeRemoved += QRCodeRemoved;
                 _qrCodesManager.QRCodeUpdated += QRCodeUpdated;
-                await StartTracking();
+                await StartTrackingAsync();
             }
         }
 
@@ -120,9 +120,9 @@ namespace Microsoft.MixedReality.SpectatorView
             }
         }
 
-        private async Task StartTracking()
+        private async Task StartTrackingAsync()
         {
-            var result = await _qrCodesManager.StartQRTracking();
+            var result = await _qrCodesManager.StartQRTrackingAsync();
             DebugLog("Started qr tracker: " + result.ToString());
         }
 


### PR DESCRIPTION
This review addresses https://github.com/microsoft/MixedReality-SpectatorView/issues/111

1) A DebugLog function is added to QRCodeMarkerDetector to cut down on log noise.
2) Capability requests for the webcam capability are relocated to the QRCodesManager and are called prior to creating the QRTracker. It appears that the capability needs to be granted prior to creating the QRTracker compared to before starting the QRTracker.