### PR TITLE
Make sure the supported localizers are still sent even when there's no ParticipantConnected event handler

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
@@ -188,17 +188,17 @@ namespace Microsoft.MixedReality.SpectatorView
             SpatialCoordinateSystemParticipant participant = new SpatialCoordinateSystemParticipant(endpoint, debugVisual, debugVisualScale);
             participants[endpoint] = participant;
             participant.ShowDebugVisuals = showDebugVisuals;
+            participant.SendSupportedLocalizersMessage(endpoint, localizers.Keys);
 
             if (ParticipantConnected == null)
             {
-                Debug.LogWarning("Participant created, but no connection listeners were found");
-                return;
+                DebugLog($"No ParticipantConnected event handlers exist");
             }
-
-            participant.SendSupportedLocalizersMessage(endpoint, localizers.Keys);
-
-            DebugLog($"Invoking ParticipantConnected event");
-            ParticipantConnected.Invoke(participant);
+            else
+            {
+                DebugLog($"Invoking ParticipantConnected event");
+                ParticipantConnected.Invoke(participant);
+            }
         }
 
         private void OnDisconnected(SocketEndpoint endpoint)


### PR DESCRIPTION
There was a recently-introduced bug when building and running the HolographicCamera app, where the list of supported localizers was never sent because there doesn't happen to be anything listening to ParticipantConnected within that scene. This changes that to no longer be a warning log and makes sure the supported localizers are always sent.