### PR TITLE
Change how IEditableSpatialLocalizationSettings works so that you can safely implement the interface even when not in UNITY_EDITOR

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/IEditableSpatialLocalizationSettings.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/IEditableSpatialLocalizationSettings.cs
@@ -6,10 +6,10 @@ using UnityEditor;
 
 namespace Microsoft.MixedReality.SpectatorView
 {
-#if UNITY_EDITOR
     public interface IEditableSpatialLocalizationSettings
     {
+#if UNITY_EDITOR
         SpatialLocalizationSettingsEditor CreateEditor();
-    }
 #endif
+    }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/MarkerDetectorLocalizationSettings.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/MarkerDetectorLocalizationSettings.cs
@@ -10,10 +10,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.SpectatorView
 {
-    public class MarkerDetectorLocalizationSettings : ISpatialLocalizationSettings
-#if UNITY_EDITOR
-        , IEditableSpatialLocalizationSettings
-#endif
+    public class MarkerDetectorLocalizationSettings : ISpatialLocalizationSettings, IEditableSpatialLocalizationSettings
     {
         public int MarkerID { get; set; }
         public float MarkerSize { get; set; } = 0.1f;


### PR DESCRIPTION
I was working on another implementation of an ISpatialLocalizer, and found the pattern I originally set up to be slightly annoying. I've changed the interface so that the member you need to implement is only defined when in UNITY_EDITOR rather than the whole type only being defined in UNITY_EDITOR. This way you can always implement the interface, and conditionally-include only the method in your implementation.