### PR TITLE
Allow external scripts to choose connecting to or listening on non-default ports

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/INetworkManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/INetworkManager.cs
@@ -27,8 +27,34 @@ namespace Microsoft.MixedReality.SpectatorView
         /// </summary>
         TimeSpan TimeSinceLastUpdate { get; }
 
+        /// <summary>
+        /// Starts a listening socket on the given port.
+        /// </summary>
+        /// <param name="port">The port to listen for new connections on.</param>
+        void StartListening(int port);
+        
+        /// <summary>
+        /// Connect to a remote device on the default port for this network manager.
+        /// </summary>
+        /// <param name="targetIpString">The IP address of the device to connect to.</param>
         void ConnectTo(string targetIpString);
+
+        /// <summary>
+        /// Connect to a remote device using the specified port.
+        /// </summary>
+        /// <param name="targetIpString">The IP address of the device to connect to.</param>
+        /// <param name="port">The port to use for communication.</param>
+        void ConnectTo(string targetIpString, int port);
+
+        /// <summary>
+        /// Disconnects any active network connections to other devices.
+        /// </summary>
         void Disconnect();
+
+        /// <summary>
+        /// Send a packet of data to all connected devices.
+        /// </summary>
+        /// <param name="data">The data to send to each connected device.</param>
         void Broadcast(byte[] data);
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkManager.cs
@@ -33,13 +33,22 @@ namespace Microsoft.MixedReality.SpectatorView
         /// </summary>
         protected abstract int RemotePort { get; }
 
-        /// <summary>
-        /// Connects to the holographic camera rig with the provided remote IP address.
-        /// </summary>
-        /// <param name="remoteAddress">The IP address of the holographic camera rig's HoloLens.</param>
+        /// <inheritdoc />
+        public void StartListening(int port)
+        {
+            connectionManager.StartListening(port);
+        }
+
+        /// <inheritdoc />
         public void ConnectTo(string remoteAddress)
         {
-            connectionManager.ConnectTo(remoteAddress, RemotePort);
+            ConnectTo(remoteAddress, RemotePort);
+        }
+
+        /// <inheritdoc />
+        public void ConnectTo(string ipAddress, int port)
+        {
+            connectionManager.ConnectTo(ipAddress, port);
         }
 
         /// <summary>

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkManager.cs
@@ -36,7 +36,14 @@ namespace Microsoft.MixedReality.SpectatorView
         /// <inheritdoc />
         public void StartListening(int port)
         {
-            connectionManager.StartListening(port);
+            if (connectionManager != null)
+            {
+                connectionManager.StartListening(port);
+            }
+            else
+            {
+                Debug.LogError($"Failed to start listening: {nameof(connectionManager)} was not assigned.");
+            }
         }
 
         /// <inheritdoc />
@@ -48,7 +55,14 @@ namespace Microsoft.MixedReality.SpectatorView
         /// <inheritdoc />
         public void ConnectTo(string ipAddress, int port)
         {
-            connectionManager.ConnectTo(ipAddress, port);
+            if (connectionManager != null)
+            {
+                connectionManager.ConnectTo(ipAddress, port);
+            }
+            else
+            {
+                Debug.LogError($"Failed to start connecting: {nameof(connectionManager)} was not assigned.");
+            }
         }
 
         /// <summary>
@@ -68,16 +82,30 @@ namespace Microsoft.MixedReality.SpectatorView
         /// </summary>
         public void Disconnect()
         {
-            connectionManager.DisconnectAll();
+            if (connectionManager != null)
+            {
+                connectionManager.DisconnectAll();
+            }
+            else
+            {
+                Debug.LogError($"Failed to disconnect: {nameof(connectionManager)} was not assigned.");
+            }
         }
 
         protected override void Awake()
         {
             base.Awake();
 
-            connectionManager.OnConnected += OnConnected;
-            connectionManager.OnDisconnected += OnDisconnected;
-            connectionManager.OnReceive += OnReceive;
+            if (connectionManager != null)
+            {
+                connectionManager.OnConnected += OnConnected;
+                connectionManager.OnDisconnected += OnDisconnected;
+                connectionManager.OnReceive += OnReceive;
+            }
+            else
+            {
+                Debug.LogError($"{nameof(connectionManager)} is required but was not assigned.");
+            }
         }
 
         protected virtual void Start()
@@ -96,12 +124,15 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             base.OnDestroy();
 
-            connectionManager.StopListening();
-            connectionManager.DisconnectAll();
+            if (connectionManager != null)
+            {
+                connectionManager.StopListening();
+                connectionManager.DisconnectAll();
 
-            connectionManager.OnConnected -= OnConnected;
-            connectionManager.OnDisconnected -= OnDisconnected;
-            connectionManager.OnReceive -= OnReceive;
+                connectionManager.OnConnected -= OnConnected;
+                connectionManager.OnDisconnected -= OnDisconnected;
+                connectionManager.OnReceive -= OnReceive;
+            }
 
             if (SpatialCoordinateSystemManager.IsInitialized)
             {


### PR DESCRIPTION
For internal demos, we sometimes set up connections on ports other than the default-configured port for a NetworkManager. This change allows an external script to connect to a port other than the RemotePort for a NetworkManager, and also allows listening on a port other than RemotePort.