### PR TITLE
Add documentation on SetupRepository.bat script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Active development occurs in MixedReality-SpectatorView's master branch. It's su
 
 ### Setting up your local environment
 
-The MixedReality-SpectatorView repository uses unity packages, git submodules and symbolic linked directories for obtaining and referencing external dependencies. Prior to opening any Unity projects, its suggested to run `tools/Scripts/SetupRepository.bat` as an administrator on your PC (On Mac or Linux, you can run `/tools/scripts/SetupRepository.sh`). This script has a few purposes:
+The MixedReality-SpectatorView repository uses Unity packages, git submodules and symbolic linked directories for obtaining and referencing external dependencies. Prior to opening any Unity projects, its suggested to run `tools/Scripts/SetupRepository.bat` as an administrator on your PC (On Mac or Linux, you can run `/tools/scripts/SetupRepository.sh`). This script has a few purposes:
 
 1. It configures your git repository to use clrf line endings and support symbolic linked directories.
 2. It obtains and updates all git submodules declared in the MixedReality-SpectatorView repository.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Active development occurs in MixedReality-SpectatorView's master branch. It's su
 
 ### Setting up your local environment
 
-The MixedReality-SpectatorView repository uses unity packages, git submodules and symbolic linked directories for obtaining and referencing external dependencies. Prior to opening any Unity projects, its suggested to run `tools/Scripts/SetupRepository.bat` on your PC (On Mac or Linux, you can run `/tools/scripts/SetupRepository.sh`). This script has a few purposes:
+The MixedReality-SpectatorView repository uses unity packages, git submodules and symbolic linked directories for obtaining and referencing external dependencies. Prior to opening any Unity projects, its suggested to run `tools/Scripts/SetupRepository.bat` as an administrator on your PC (On Mac or Linux, you can run `/tools/scripts/SetupRepository.sh`). This script has a few purposes:
 
 1. It configures your git repository to use clrf line endings and support symbolic linked directories.
 2. It obtains and updates all git submodules declared in the MixedReality-SpectatorView repository.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,31 @@ Spectator View is an augmented reality product that enables viewing HoloLens exp
 
 ## Getting Started
 
-### Obtaining the Code
+### Obtaining the code
 
 Active development occurs in MixedReality-SpectatorView's master branch. It's suggested to consume Spectator View code from one of the release branches compared to the master branch.
 
 >Note: Spectator view uses symbolic linked directories in its sample projects, which results in large file paths. It's suggested to place your Unity project in a short named directory (such as C:\sv). Otherwise, file paths may become too long to resolve in Unity.
 
+### Setting up your local environment
+
+The MixedReality-SpectatorView repository uses unity packages, git submodules and symbolic linked directories for obtaining and referencing external dependencies. Prior to opening any Unity projects, its suggested to run `tools/Scripts/SetupRepository.bat` on your PC (On Mac or Linux, you can run `/tools/scripts/SetupRepository.sh`). This script has a few purposes:
+
+1. It configures your git repository to use clrf line endings and support symbolic linked directories.
+2. It obtains and updates all git submodules declared in the MixedReality-SpectatorView repository.
+3. It fixes any symbolic linked directories in the MixedReality-SpectatorView respository.
+
+> Note: Not all submodules have the same [MIT license](LICENSE) as the MixedReality-SpectatorView repository. Submodules in this project currently include: [MixedRealityToolkit-Unity](https://github.com/microsoft/MixedRealityToolkit-Unity), [Azure-Spatial-Anchors-Samples](https://github.com/Azure/azure-spatial-anchors-samples) and [ARCore-Unity-SDK](https://github.com/google-ar/arcore-unity-sdk). You should view and accept the licenses in these projects before running the [SetupRepository.bat](tools/Scripts/SetupRepository.bat) script.
+
+### Samples
+
+It's easy to get started by building off one of the samples, or inspecting them to understand project setup. For more information, see [Samples](samples/README.md).
+
+## Setting up your own project
+
 ### Basic Setup
 
-Below are simple instructions for adding Spectator View to your project. For more robust setup instructions, see the 'Setup' section below.
+Below are simple instructions for adding Spectator View to your project:
 
 1. Ensure you have all of the [Software & Hardware](doc/SpectatorView.Setup.md##Software%20%26%20Hardware%20Requirements).
     - Ensure you have added the appropriate platform dependencies to your project (ARCore/ARKit)
@@ -29,24 +45,21 @@ Below are simple instructions for adding Spectator View to your project. For mor
 
 > Note: Some platforms require a special build step, for build information see: [Building & Deploying](doc/SpectatorView.Setup.md###Building%20%26%20Deploying)
 
-### Samples
+### Detailed Setup
+For more information on setting up a Spectator View project, see the following pages:
 
-It's also easy to get started by building off one of the samples, or inspecting them to understand project setup. For more information, see [Samples](samples/README.md).
+* [Spectating with an Android or iOS device](doc/SpectatorView.Setup.md)
+* [Spectating with a video camera](doc/SpectatorView.Setup.VideoCamera.md)
 
 ## Architecture
 
 For more information on Spectator View's architecture, see [here](doc/SpectatorView.Architecture.md).
 
-## Setup
-
-* [**Spectating with an Android or iOS device**](doc/SpectatorView.Setup.md)
-* [**Spectating with a video camera**](doc/SpectatorView.Setup.VideoCamera.md)
-
 ## Debugging
 
 For more information on debugging Spectator View, see [here](doc/SpectatorView.Debugging.md)
 
-## Filing Feedback
+## Filing feedback
 
 The easiest way to file feedback is by [opening an issue](https://github.com/microsoft/MixedReality-SpectatorView/issues). When filing feedback, please include the following information (when applicable):
 

--- a/doc/SpectatorView.Architecture.md
+++ b/doc/SpectatorView.Architecture.md
@@ -32,16 +32,16 @@
 
 ### Spatial alignment
 
-For more information on spatial alignment, see [SpectatorView.SpatialAlignment](../src/SpectatorView.Unity/Assets/SpatialAlignment/README.md)
+For more information on spatial alignment, see [here](../src/SpectatorView.Unity/Assets/SpatialAlignment/README.md).
 
 ### State synchronization
 
-For more information on state synchronization, see [SpectatorView.StateSynchronization](../src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/README.md)
+For more information on state synchronization, see [here](../src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/README.md).
 
-### Compositing and Recording
+### Screen Recording
 
-For more information on compositing and recording, see [SpectatorView.Recording](../src/SpectatorView.Unity/Assets/SpectatorView/Scripts/ScreenRecording/README.md)
+For more information on compositing and recording, see [here](../src/SpectatorView.Unity/Assets/SpectatorView/Scripts/ScreenRecording/README.md).
 
-### Calibration
+### Video Camera Recording
 
-For more information on calibration, see [SpectatorView.Calibration](../src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Calibration/README.md)
+For more information on recording with a video camera, see [here](../src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/README.md).

--- a/tools/Scripts/SetupRepository.ps1
+++ b/tools/Scripts/SetupRepository.ps1
@@ -37,15 +37,23 @@ Set-Location (Split-Path $MyInvocation.MyCommand.Path)
 # for inter-directory linking to build the HolographicCamera.Unity project
 # as well as for the samples to include submodule repository content
 # via directory symlinks.
+Write-Output "Enabling symbolic link directories for the repository."
 git config core.symlinks true
 
-# Ensure that submodules are initialized and cloned
+# Ensure consistent line endings.
+Write-Output "Configuring the repository to use crlf line endings."
+git config core.autocrlf true
+
+# Ensure that submodules are initialized and cloned.
+Write-Output "Updating all submodules."
 git submodule update --init
 
 # If any links were created to the submodules but were broken,
 # restore those symlinks now that the submodules are cloned.
+Write-Output "Updating all symbolic link directories."
 dir "$PSScriptRoot\..\..\" -Recurse -File | ?{$_.LinkType -eq "SymbolicLink" } | Restore-SymbolicLink
 
 # If any links were created before the repository was configured to use
 # symlinks, those links need to be restored.
+Write-Output "Fixing any custom symbolic links."
 git status --porcelain | Restore-SymbolicLinkFromTypeChange

--- a/tools/Scripts/SetupRepository.ps1
+++ b/tools/Scripts/SetupRepository.ps1
@@ -37,7 +37,7 @@ Set-Location (Split-Path $MyInvocation.MyCommand.Path)
 # for inter-directory linking to build the HolographicCamera.Unity project
 # as well as for the samples to include submodule repository content
 # via directory symlinks.
-Write-Output "Enabling symbolic link directories for the repository."
+Write-Output "Enabling symbolic links for the repository."
 git config core.symlinks true
 
 # Ensure consistent line endings.
@@ -50,10 +50,9 @@ git submodule update --init
 
 # If any links were created to the submodules but were broken,
 # restore those symlinks now that the submodules are cloned.
-Write-Output "Updating all symbolic link directories."
+Write-Output "Fixing all symbolic links."
 dir "$PSScriptRoot\..\..\" -Recurse -File | ?{$_.LinkType -eq "SymbolicLink" } | Restore-SymbolicLink
 
 # If any links were created before the repository was configured to use
 # symlinks, those links need to be restored.
-Write-Output "Fixing any custom symbolic links."
 git status --porcelain | Restore-SymbolicLinkFromTypeChange

--- a/tools/Scripts/SetupRepository.sh
+++ b/tools/Scripts/SetupRepository.sh
@@ -4,6 +4,7 @@
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 git config core.symlinks true
+git config core.autocrlf true
 git submodule update --init
 find $SCRIPTPATH/../../samples -type l | xargs rm
 git checkout -f -- :/samples


### PR DESCRIPTION
This review contains a few changes:

1) The landing page now has information on the SetupRepository.bat step
2) SetupRepository setup scripts are updated to configure the repo for crlf line endings. This should prevent line ending changes that make viewing pull requests more difficult.
3) A few documentation pages calling out a deleted calibration doc have been fixed.