### PR TITLE
Fix QR Localizers to not declare themselves as available on HoloLens 1

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -204,7 +204,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             {
                 selectedLocalizerIndex = EditorGUILayout.Popup(selectedLocalizerIndex, localizerNames);
                 if (localizers != null &&
-                    localizers.Length> selectedLocalizerIndex)
+                    selectedLocalizerIndex < localizers.Length)
                 {
                     selectedLocalizerId = localizers[selectedLocalizerIndex].SpatialLocalizerId;
                     SpatialLocalizationSettingsGUI(deviceTypeLabel, selectedLocalizerIndex, localizers);

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -171,12 +171,20 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 {
                     localizers = SpatialCoordinateSystemManager.Instance.Localizers.Where(localizer => supportedPeerLocalizers.Result.Contains(localizer.SpatialLocalizerId)).ToArray();
                     localizerNames = localizers.Select(localizer => localizer.DisplayName).ToArray();
-                    for (int i = 0; i < localizers.Length; i++)
+                    if (localizerNames.Length == 0)
                     {
-                        if (localizers[i].SpatialLocalizerId == selectedLocalizerId)
+                        GUI.enabled = false;
+                        localizerNames = new string[] { "No supported localization methods found." };
+                    }
+                    else
+                    {
+                        for (int i = 0; i < localizers.Length; i++)
                         {
-                            selectedLocalizerIndex = i;
-                            break;
+                            if (localizers[i].SpatialLocalizerId == selectedLocalizerId)
+                            {
+                                selectedLocalizerIndex = i;
+                                break;
+                            }
                         }
                     }
                 }
@@ -195,12 +203,12 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             GUILayout.BeginHorizontal();
             {
                 selectedLocalizerIndex = EditorGUILayout.Popup(selectedLocalizerIndex, localizerNames);
-                if (localizers != null)
+                if (localizers != null &&
+                    localizers.Length> selectedLocalizerIndex)
                 {
                     selectedLocalizerId = localizers[selectedLocalizerIndex].SpatialLocalizerId;
+                    SpatialLocalizationSettingsGUI(deviceTypeLabel, selectedLocalizerIndex, localizers);
                 }
-
-                SpatialLocalizationSettingsGUI(deviceTypeLabel, selectedLocalizerIndex, localizers);
             }
             GUILayout.EndHorizontal();
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/QRCodeMarkerVisualDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/QRCodeMarkerVisualDetectorSpatialLocalizer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             get
             {
-#if QRCODESTRACKER_BINARY_AVAILABLE && UNITY_WSA
-                return true;
+#if QRCODESTRACKER_BINARY_AVAILABLE && UNITY_WSA && !UNITY_EDITOR
+                return (Windows.ApplicationModel.Package.Current.Id.Architecture != Windows.System.ProcessorArchitecture.X86); // HoloLens 1 is not supported.
 #else
                 return false;
 #endif

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/ArUcoMarkerDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/ArUcoMarkerDetectorSpatialLocalizer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.SpectatorView
             get
             {
 #if UNITY_EDITOR
-                // We return true for the editor so that this localizer registers as supported by the Unity editor for composited video camera experiences.
+                // We return true for the editor so that this localizer registers as available for video camera compositing scenarios.
                 return true;
 #elif UNITY_WSA
                 return Windows.ApplicationModel.Package.Current.Id.Architecture == Windows.System.ProcessorArchitecture.X86;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/ArUcoMarkerDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/ArUcoMarkerDetectorSpatialLocalizer.cs
@@ -22,6 +22,7 @@ namespace Microsoft.MixedReality.SpectatorView
             get
             {
 #if UNITY_EDITOR
+                // We return true for the editor so that this localizer registers as supported by the Unity editor for composited video camera experiences.
                 return true;
 #elif UNITY_WSA
                 return Windows.ApplicationModel.Package.Current.Id.Architecture == Windows.System.ProcessorArchitecture.X86;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/QRCodeMarkerDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/QRCodeMarkerDetectorSpatialLocalizer.cs
@@ -21,8 +21,11 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             get
             {
-#if UNITY_WSA && QRCODESTRACKER_BINARY_AVAILABLE
+#if UNITY_EDITOR
+                // We return true for the editor so that this localizer registers as supported by the Unity editor for composited video camera experiences.
                 return true;
+#elif QRCODESTRACKER_BINARY_AVAILABLE && UNITY_WSA
+                return (Windows.ApplicationModel.Package.Current.Id.Architecture != Windows.System.ProcessorArchitecture.X86); // HoloLens 1 is not supported.
 #else
                 return false;
 #endif

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/QRCodeMarkerDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/QRCodeMarkerDetectorSpatialLocalizer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.SpectatorView
             get
             {
 #if UNITY_EDITOR
-                // We return true for the editor so that this localizer registers as supported by the Unity editor for composited video camera experiences.
+                // We return true for the editor so that this localizer registers as available for video camera compositing scenarios.
                 return true;
 #elif QRCODESTRACKER_BINARY_AVAILABLE && UNITY_WSA
                 return (Windows.ApplicationModel.Package.Current.Id.Architecture != Windows.System.ProcessorArchitecture.X86); // HoloLens 1 is not supported.


### PR DESCRIPTION
There are a few changes in this review:

1) QR Code based localizers now don't declare themselves as supported on HoloLens 1.
2) The compositor UI has been updated to handle scenarios where no localizers are supported by a connected device.