### PR TITLE
Update the readme setup steps to have a correct GoogleARCore location

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After obtaining a local clone of the MixedReality-SpectatorView repository and r
 * `mklink /D "MixedReality-SpectatorView" "%PathToRepo%\MixedReality-SpectatorView\src\SpectatorView.Unity\Assets"`
 * `mklink /D "ARKit-Unity-Plugin" "%PathToRepo%\MixedReality-SpectatorView\external\ARKit-Unity-Plugin"`
 * `mklink /D "AzureSpatialAnchorsPlugin" "%PathToRepo%\MixedReality-SpectatorView\external\Azure-Spatial-Anchors-Samples\Unity\Assets\AzureSpatialAnchorsPlugin"`
-* `mklink /D "GoogleARCore" "%PathToRepo%\MixedReality-SpectatorView\external\GoogleARCore"`
+* `mklink /D "GoogleARCore" "%PathToRepo%\MixedReality-SpectatorView\external\ARCore-Unity-SDK\Assets"`
 * `mklink /D "MixedReality-QRCodePlugin" "%PathToRepo%\MixedReality-SpectatorView\external\MixedReality-QRCodePlugin"`
 * `mkdir AzureSpatialAnchors.Resources`
 * `cd AzureSpatialAnchors.Resources`


### PR DESCRIPTION
Walking through these steps, I hit an issue where GoogleARCore wasnt a valid folder to use - GoogleARCore doesn't exist as a folder at that location based on the setup steps in the tooling.

I'm not 100% sure if we should only be including GoogleARCore, or if we want to include the rest of the ARCore assets