### PR TITLE
Ensure that GameObjects in the DontDestroyOnLoad scene are broadcast

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationBroadcaster.cs
@@ -29,6 +29,8 @@ namespace Microsoft.MixedReality.SpectatorView
         private const float PerfUpdateTimeSeconds = 1.0f;
         private float timeUntilNextPerfUpdate = PerfUpdateTimeSeconds;
 
+        private GameObject dontDestroyOnLoadGameObject;
+        
         protected override int RemotePort => Port;
 
         protected override void Awake()
@@ -131,6 +133,21 @@ namespace Microsoft.MixedReality.SpectatorView
                     {
                         ComponentExtensions.EnsureComponent<TransformBroadcaster>(root);
                     }
+                }
+
+                // GameObjects that are marked DontDestroyOnLoad exist in a special scene, and that scene
+                // cannot be enumerated via the SceneManager. The only way to access that scene is from a
+                // GameObject inside that scene, so we need to create a GameObject we have access to inside
+                // that scene in order to enumerate all of its root GameObjects.
+                if (dontDestroyOnLoadGameObject == null)
+                {
+                    dontDestroyOnLoadGameObject = new GameObject("StateSynchronizationBroadcaster_DontDestroyOnLoad");
+                    DontDestroyOnLoad(dontDestroyOnLoadGameObject);
+                }
+
+                foreach (GameObject root in dontDestroyOnLoadGameObject.scene.GetRootGameObjects())
+                {
+                    ComponentExtensions.EnsureComponent<TransformBroadcaster>(root);
                 }
             }
         }


### PR DESCRIPTION
When you call DontDestroyOnLoad on a GameObject, it gets moved to a special scene. This scene cannot be enumerated via the SceneManager, and the only way I've discovered to access the scene to enumerate its root GameObjects is to actually create an object and mark it DontDestroyOnLoad, then use its .scene property.