### PR TITLE
Fix two issues with asset cache updating

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationMenuItems.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationMenuItems.cs
@@ -12,23 +12,51 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 {
     public static class StateSynchronizationMenuItems
     {
+        private static IEqualityComparer<IAssetCache> assetTypeComparer = new AssetCacheTypeEqualityComparer();
+
+        private class AssetCacheTypeEqualityComparer : IEqualityComparer<IAssetCache>
+        {
+            public bool Equals(IAssetCache x, IAssetCache y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+                if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                {
+                    return false;
+                }
+
+                return x.GetType().Equals(y.GetType());
+            }
+
+            public int GetHashCode(IAssetCache obj)
+            {
+                return obj.GetType().GetHashCode();
+            }
+        }
+
+        private static IEnumerable<IAssetCache> GetAllAssetCaches()
+        {
+            var assetCaches = AssetCache.EnumerateAllComponentsInScenesAndPrefabs<IAssetCache>();
+            return assetCaches.Distinct(assetTypeComparer);
+        }
+
         [MenuItem("Spectator View/Update All Asset Caches", priority = 100)]
         public static void UpdateAllAssetCaches()
         {
             bool assetCacheFound = false;
-            var scene = SceneManager.GetActiveScene();
-            foreach (GameObject root in scene.GetRootGameObjects())
+
+            foreach (IAssetCache assetCache in GetAllAssetCaches())
             {
-                foreach (IAssetCache assetCache in root.GetComponentsInChildren<IAssetCache>(includeInactive: true))
-                {
-                    assetCacheFound = true;
-                    assetCache.UpdateAssetCache();
-                }
+                Debug.Log($"Updating asset cache {assetCache.GetType().Name}...");
+                assetCache.UpdateAssetCache();
+                assetCacheFound = true;
             }
 
             if (!assetCacheFound)
             {
-                Debug.LogWarning("No asset caches were found in the scene. Unable to update asset caches.");
+                Debug.LogWarning("No asset caches were found in the project. Unable to update asset caches.");
                 return;
             }
 
@@ -40,19 +68,17 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         public static void ClearAllAssetCaches()
         {
             bool assetCacheFound = false;
-            var scene = SceneManager.GetActiveScene();
-            foreach (GameObject root in scene.GetRootGameObjects())
+
+            foreach (IAssetCache assetCache in GetAllAssetCaches())
             {
-                foreach (IAssetCache assetCache in root.GetComponentsInChildren<IAssetCache>(includeInactive: true))
-                {
-                    assetCacheFound = true;
-                    assetCache.ClearAssetCache();
-                }
+                Debug.Log($"Clearing asset cache {assetCache.GetType().Name}...");
+                assetCache.ClearAssetCache();
+                assetCacheFound = true;
             }
 
             if (!assetCacheFound)
             {
-                Debug.LogWarning("No asset caches were found in the scene. Unable to clear asset caches.");
+                Debug.LogWarning("No asset caches were found in the project. Unable to clear asset caches.");
                 return;
             }
 


### PR DESCRIPTION
1. Make sure that the initial creation of an asset cache is not nulled out by AssetDatabase.SaveAssets and AssetDatabase.Refresh
2. Enumerate all scenes and prefabs to find the set of IAssetCaches to update so that they don't need to be in the currently-open scene