### PR TITLE
Change how we handle changes variable usage warnings across platforms.

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Calibration/CompositorWrapper.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Calibration/CompositorWrapper.cs
@@ -12,11 +12,10 @@ namespace Microsoft.MixedReality.SpectatorView
         /// </summary>
         [Tooltip("CompositionManager used to obtain the DSLR stream")]
         [SerializeField]
-#if UNITY_EDITOR
+#pragma warning disable 414 // The field is assigned but its value is never used
         private CompositionManager compositionManager = null;
-#else
-        private CompositionManager compositionManager;
-#endif
+#pragma warning restore 414
+
 
         public RenderTexture GetVideoCameraFeed()
         {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Calibration/EditorExtrinsicsCalibration.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Calibration/EditorExtrinsicsCalibration.cs
@@ -33,11 +33,9 @@ namespace Microsoft.MixedReality.SpectatorView
         /// </summary>
         [Tooltip("The HolographicCameraObserver that establishes a network connection with the Holographic Camera.")]
         [SerializeField]
-#if UNITY_EDITOR
+#pragma warning disable 414 // The field is assigned but its value is never used
         HolographicCameraObserver holographicCameraObserver = null;
-#else
-        HolographicCameraObserver holographicCameraObserver;
-#endif
+#pragma warning restore 414
 
         [Header("UI Parameters")]
         /// <summary>

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/ArUcoMarkerDetector.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/ArUcoMarkerDetector.cs
@@ -46,11 +46,14 @@ namespace Microsoft.MixedReality.SpectatorView
         private HoloLensCamera _holoLensCamera;
         private SpectatorViewOpenCVInterface _api = null;
         private bool _detecting = false;
-        private Dictionary<int, List<Marker>> _markerObservations = null;
         private Dictionary<int, Marker> _nextMarkerUpdate;
         private MarkerDetectionCompletionStrategy _detectionCompletionStrategy;
         private object lockObj = new object();
         private Task setupCameraTask = null;
+
+#pragma warning disable 414 // The field is assigned but its value is never used
+        private Dictionary<int, List<Marker>> _markerObservations = null;
+#pragma warning restore 414
 
         [HideInInspector]
         public int RequiredObservations = 5;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
@@ -44,11 +44,9 @@ namespace Microsoft.MixedReality.SpectatorView
         /// </summary>
         [Tooltip("Default prefab for creating a mobile network configuration visual.")]
         [SerializeField]
-#if UNITY_IOS || UNITY_ANDROID
+#pragma warning disable 414 // The field is assigned but its value is never used
         private GameObject defaultMobileNetworkConfigurationVisualPrefab = null;
-#else
-        private GameObject defaultMobileNetworkConfigurationVisualPrefab;
-#endif
+#pragma warning restore 414
 
         [Header("State Synchronization")]
         /// <summary>
@@ -83,11 +81,9 @@ namespace Microsoft.MixedReality.SpectatorView
         /// </summary>
         [Tooltip("Default prefab for creating a mobile recording service visual.")]
         [SerializeField]
-#if UNITY_IOS || UNITY_ANDROID
+#pragma warning disable 414 // The field is assigned but its value is never used
         private GameObject defaultMobileRecordingServiceVisualPrefab = null;
-#else
-        private GameObject defaultMobileRecordingServiceVisualPrefab;
-#endif
+#pragma warning restore 414
 
         [Header("Debugging")]
         /// <summary>

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/DeviceInfoBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/DeviceInfoBroadcaster.cs
@@ -20,7 +20,9 @@ namespace Microsoft.MixedReality.SpectatorView
     public class DeviceInfoBroadcaster : MonoBehaviour
     {
         [SerializeField]
+#pragma warning disable 414 // The field is assigned but its value is never used
         private TCPConnectionManager connectionManager = null;
+#pragma warning restore 414
 
 #if UNITY_WSA
         private void Awake()


### PR DESCRIPTION
This review changes how we declare variables that are used/unused based on changing the unity player. We need to avoid warnings for known scenarios such as these. In some build environments, warnings get automatically treated as errors.

This review also addresses https://github.com/microsoft/MixedReality-SpectatorView/issues/114