### PR TITLE
Fix the branch name that the MixedRealityToolkit-Unity refers to

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/MixedRealityToolkit-Unity"]
 	path = external/MixedRealityToolkit-Unity
 	url = https://github.com/microsoft/MixedRealityToolkit-Unity
-	branch = mrtk_release
+	branch = mrtk_development
 	ignore = dirty
 [submodule "external/ARCore-Unity-SDK"]
 	path = external/ARCore-Unity-SDK


### PR DESCRIPTION
Currently MixedReality-SpectatorView is on a commit from mrtk_development. Until this gets merged to mrtk_release, the submodule should indicate the correct branch.