### PR TITLE
Add a ComponentBroadcasterService for RectMask2D

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/SpectatorView.prefab
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/SpectatorView.prefab
@@ -88,309 +88,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9de2b7859644fbd409cf9c1a2bb52d9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &4941633253159564293
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4941633253159564536}
-  - component: {fileID: 4941633253159564537}
-  - component: {fileID: 4941633253159564534}
-  - component: {fileID: 4941633253159564535}
-  - component: {fileID: 4941633253159564532}
-  - component: {fileID: 4941633253159564533}
-  - component: {fileID: 4941633253159564530}
-  - component: {fileID: 4941633253159564531}
-  - component: {fileID: 4941633253159564528}
-  - component: {fileID: 4941633253159564529}
-  - component: {fileID: 4941633253159564302}
-  - component: {fileID: 4941633253159564303}
-  - component: {fileID: 4941633253159564300}
-  - component: {fileID: 4941633253159564301}
-  - component: {fileID: 4941633253159564298}
-  - component: {fileID: 4941633253159564299}
-  - component: {fileID: 4941633253159564296}
-  - component: {fileID: 4941633253159564297}
-  - component: {fileID: 4941633253159564294}
-  - component: {fileID: 4941633253159564295}
-  - component: {fileID: 4941633253159564292}
-  - component: {fileID: 4941633253159564539}
-  m_Layer: 0
-  m_Name: StateSynchronization Assets
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &4941633253159564536
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4941633254374932147}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4941633253159564537
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b7a21ab2fbede343a7695b9bcd313c1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564534
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e0ae47a78b935149a3a8d21c981b64d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564535
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4a4f39f231b2e32439c349db11a55102, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564532
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 882ecbba337804d49b8a0ae4580f991b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564533
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b1de421cfd139c419457ca59d20cc4a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564530
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9914c89724c7cad4e81b82616d04fd96, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564531
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db9578ba09320674ebfd2c7b7b8c0021, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564528
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c7555c9e8d1591c42b69404f07cda8d6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564529
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: afade379e2b751546ad5d6acde4f76de, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564302
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 77a963ff93dce3441b5447433e9ea2d2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564303
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fc81dbe9d5ff9874ab8c553ef9fd2712, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564300
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d32081b9450f8364d9ba927594c4b89a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564301
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d87a61af73642764abeaa7fef2d9b3c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0778c650da026744abf6fef44494022f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564299
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3a2c0904479176e44bee3892a5023d01, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564296
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8ad08b83e64ac63488fe19b95170861d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564297
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a74bf6d7a1c9cad4ab28e488617b15fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564294
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a43d1daf0b5c43d44b238200633c64e8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564295
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 04dbfee207a40804fbf410c5ff28801d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564292
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea8966d9bbe6eda469c0c206d7f054bc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4941633253159564539
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4941633253159564293}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fa64e43c5d4d26d4eade391bc1f935ae, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &4941633254257257631
 GameObject:
   m_ObjectHideFlags: 0
@@ -501,10 +198,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Role: 0
   userIpAddress: 127.0.0.1
-  useMobileNetworkConfigurationVisual: 1
   defaultMobileNetworkConfigurationVisualPrefab: {fileID: 9128832365225436076, guid: e14699ad6aa64ed459c4ecba1c9f6001,
     type: 3}
-  stateSynchronizationSceneManager: {fileID: 4941633253159564537}
+  stateSynchronizationSceneManager: {fileID: 0}
   stateSynchronizationBroadcaster: {fileID: 4941633254549859856}
   stateSynchronizationObserver: {fileID: 4941633254517527404}
   defaultSpatialLocalizationInitializers:
@@ -549,7 +245,7 @@ Transform:
   - {fileID: 4941633253096476541}
   - {fileID: 4941633254549859859}
   - {fileID: 4941633254517527407}
-  - {fileID: 4941633253159564536}
+  - {fileID: 4715176406495730954}
   m_Father: {fileID: 4941633254297953243}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -666,11 +362,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4941633254257257630}
     m_Modifications:
-    - target: {fileID: 2053685663436622530, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
-        type: 3}
-      propertyPath: m_Name
-      value: SpectatorView.SpatialCoordinateLocalizers
-      objectReference: {fileID: 0}
     - target: {fileID: 5795882921077350206, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -726,20 +417,19 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2053685663436622530, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
+        type: 3}
+      propertyPath: m_Name
+      value: SpectatorView.SpatialCoordinateLocalizers
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7f5fdf2d931ebfc44a472a374ccc191e, type: 3}
---- !u!114 &7339675784917655566 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 201468391369661480, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
+--- !u!4 &3998944255825601304 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5795882921077350206, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
     type: 3}
   m_PrefabInstance: {fileID: 7426442734984199206}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 65428d5b29901f54f9201e5ca29bdb10, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &5317805835895109800 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3376752394934518926, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
@@ -752,9 +442,90 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 65428d5b29901f54f9201e5ca29bdb10, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &3998944255825601304 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5795882921077350206, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
+--- !u!114 &7339675784917655566 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 201468391369661480, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
     type: 3}
   m_PrefabInstance: {fileID: 7426442734984199206}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65428d5b29901f54f9201e5ca29bdb10, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &8145183886527470022
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4941633254374932147}
+    m_Modifications:
+    - target: {fileID: 3487521567490933809, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_Name
+      value: StateSynchronizationAssets
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df296c708e424ae44af8ee68d559f3b4, type: 3}
+--- !u!4 &4715176406495730954 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3487521567490933964, guid: df296c708e424ae44af8ee68d559f3b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8145183886527470022}
   m_PrefabAsset: {fileID: 0}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/SpectatorView.prefab
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/SpectatorView.prefab
@@ -200,7 +200,7 @@ MonoBehaviour:
   userIpAddress: 127.0.0.1
   defaultMobileNetworkConfigurationVisualPrefab: {fileID: 9128832365225436076, guid: e14699ad6aa64ed459c4ecba1c9f6001,
     type: 3}
-  stateSynchronizationSceneManager: {fileID: 0}
+  stateSynchronizationSceneManager: {fileID: 4715176406495730955}
   stateSynchronizationBroadcaster: {fileID: 4941633254549859856}
   stateSynchronizationObserver: {fileID: 4941633254517527404}
   defaultSpatialLocalizationInitializers:
@@ -362,6 +362,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4941633254257257630}
     m_Modifications:
+    - target: {fileID: 2053685663436622530, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
+        type: 3}
+      propertyPath: m_Name
+      value: SpectatorView.SpatialCoordinateLocalizers
+      objectReference: {fileID: 0}
     - target: {fileID: 5795882921077350206, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -416,11 +421,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2053685663436622530, guid: 7f5fdf2d931ebfc44a472a374ccc191e,
-        type: 3}
-      propertyPath: m_Name
-      value: SpectatorView.SpatialCoordinateLocalizers
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7f5fdf2d931ebfc44a472a374ccc191e, type: 3}
@@ -529,3 +529,15 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8145183886527470022}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4715176406495730955 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3487521567490933965, guid: df296c708e424ae44af8ee68d559f3b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8145183886527470022}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b7a21ab2fbede343a7695b9bcd313c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/StateSynchronizationAssets.prefab
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/StateSynchronizationAssets.prefab
@@ -30,6 +30,7 @@ GameObject:
   - component: {fileID: 3487521567490933811}
   - component: {fileID: 3487521567490933808}
   - component: {fileID: 3487521567490933967}
+  - component: {fileID: 5370918206105573797}
   m_Layer: 0
   m_Name: StateSynchronizationAssets
   m_TagString: Untagged
@@ -301,5 +302,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fa64e43c5d4d26d4eade391bc1f935ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5370918206105573797
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3487521567490933809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17279b8784438744aa088057a8b4abc4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0cfddae1248164148af40f3d63858c8a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DBroadcaster.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Microsoft.MixedReality.SpectatorView
+{
+    internal class RectMask2DBroadcaster : ComponentBroadcaster<RectMask2DService, RectMask2DBroadcaster.ChangeType>
+    {
+        [Flags]
+        public enum ChangeType : byte
+        {
+            None = 0x0,
+            Properties = 0x1
+        }
+
+        private RectMask2D rectMask2D;
+        private bool previousEnabled;
+
+        protected override void Awake()
+        {
+            base.Awake();
+
+            this.rectMask2D = GetComponent<RectMask2D>();
+        }
+
+        public static bool HasFlag(ChangeType changeType, ChangeType flag)
+        {
+            return (changeType & flag) == flag;
+        }
+
+        protected override bool HasChanges(ChangeType changeFlags)
+        {
+            return changeFlags != ChangeType.None;
+        }
+
+        protected override ChangeType CalculateDeltaChanges()
+        {
+            ChangeType changeType = ChangeType.None;
+            bool newEnabled = rectMask2D.enabled;
+            if (newEnabled != previousEnabled)
+            {
+                previousEnabled = newEnabled;
+                changeType |= ChangeType.Properties;
+            }
+
+            return changeType;
+        }
+
+        protected override void SendCompleteChanges(IEnumerable<SocketEndpoint> endpoints)
+        {
+            previousEnabled = rectMask2D.enabled;
+            SendDeltaChanges(endpoints, ChangeType.Properties);
+        }
+
+        protected override void SendDeltaChanges(IEnumerable<SocketEndpoint> endpoints, ChangeType changeFlags)
+        {
+            using (MemoryStream memoryStream = new MemoryStream())
+            using (BinaryWriter message = new BinaryWriter(memoryStream))
+            {
+                ComponentBroadcasterService.WriteHeader(message, this);
+
+                message.Write((byte)changeFlags);
+
+                if (HasFlag(changeFlags, ChangeType.Properties))
+                {
+                    message.Write(previousEnabled);
+                }
+
+                message.Flush();
+                StateSynchronizationSceneManager.Instance.Send(endpoints, memoryStream.ToArray());
+            }
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DBroadcaster.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DBroadcaster.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 2fca59d498954254ba6c8b6651bdd2c8
+timeCreated: 1522948366
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DObserver.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.IO;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Microsoft.MixedReality.SpectatorView
+{
+    internal class RectMask2DObserver : ComponentObserver<RectMask2D>
+    {
+        public override void Read(SocketEndpoint sendingEndpoint, BinaryReader message)
+        {
+            RectMask2DBroadcaster.ChangeType changeType = (RectMask2DBroadcaster.ChangeType)message.ReadByte();
+
+            if (RectMask2DBroadcaster.HasFlag(changeType, RectMask2DBroadcaster.ChangeType.Properties))
+            {
+                if (attachedComponent == null)
+                {
+                    attachedComponent = gameObject.AddComponent<RectMask2D>();
+                }
+
+                attachedComponent.enabled = message.ReadBoolean();
+            }
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DObserver.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DObserver.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 231d22171df502740adf334e219945a1
+timeCreated: 1522949357
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DService.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.SpectatorView
 {
     internal class RectMask2DService : ComponentBroadcasterService<RectMask2DService, RectMask2DObserver>
     {
-        public static readonly ShortID ID = new ShortID("RM2");
+        public static readonly ShortID ID = new ShortID("RMK");
 
         public override ShortID GetID() { return ID; }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DService.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Microsoft.MixedReality.SpectatorView
+{
+    internal class RectMask2DService : ComponentBroadcasterService<RectMask2DService, RectMask2DObserver>
+    {
+        public static readonly ShortID ID = new ShortID("RM2");
+
+        public override ShortID GetID() { return ID; }
+
+        private void Start()
+        {
+            StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<RectMask2DBroadcaster>(typeof(RectMask2D)));
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DService.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/RectMask2D/RectMask2DService.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 17279b8784438744aa088057a8b4abc4
+timeCreated: 1527023244
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationSceneManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationSceneManager.cs
@@ -60,6 +60,12 @@ namespace Microsoft.MixedReality.SpectatorView
         /// <param name="componentDefinition">The definition controlling when a component should be broadcast.</param>
         public void RegisterService(IComponentBroadcasterService service, ComponentBroadcasterDefinition componentDefinition)
         {
+            if (componentBroadcasterServices.TryGetValue(service.GetID(), out IComponentBroadcasterService existingService))
+            {
+                Debug.LogError($"Duplicate IComponentBroadcasterService key detected: {service.GetID().ToString()} was previously registered for a service with type {existingService.GetType().Name} and now it is being re-registered for a service with type {service.GetType().Name}.");
+                return;
+            }
+
             componentBroadcasterDefinitions.Add(componentDefinition);
             componentBroadcasterServices.Add(service.GetID(), service);
         }


### PR DESCRIPTION
This change adds a broadcaster and observer for RectMask2D. This change also modifies the SpectatorView prefab to refer to the StateSynchronizationAssets prefab so that future new services can be added only in one prefab.