### PR TITLE
Re-enable the normal rendering path when not using quad view

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/HoloAlpha.mat
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/HoloAlpha.mat
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: HoloAlpha
+  m_Shader: {fileID: 4800000, guid: c8a28ad8c8326d048a8a0af8fa87e004, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BackTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _FronTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Alpha: 0.9
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/HoloAlpha.mat.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/HoloAlpha.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6ccb227e15dc2945b6d000bc0b0d157
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -118,9 +118,13 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
                 EditorGUILayout.BeginHorizontal("Box");
                 {
-                    string[] compositionOptions = new string[] { "Final composited texture", "Quadrant with intermediate textures" };
-                    GUIContent renderingModeLabel = new GUIContent("Display texture", "Choose between displaying the composited video texture or seeing intermediate textures displayed in 4 sections (bottom left: input video, top left: opaque hologram, top right: hologram alpha mask, bottom right: hologram alpha-blended onto video)");
+                    string[] compositionOptions = new string[] { "Final composite", "Intermediate textures" };
+                    GUIContent renderingModeLabel = new GUIContent("Preview display", "Choose between displaying the composited video texture or seeing intermediate textures displayed in 4 sections (bottom left: input video, top left: opaque hologram, top right: hologram alpha mask, bottom right: hologram alpha-blended onto video)");
                     textureRenderMode = EditorGUILayout.Popup(renderingModeLabel, textureRenderMode, compositionOptions);
+                    if (compositionManager != null && compositionManager.TextureManager != null)
+                    {
+                        compositionManager.TextureManager.IsQuadrantVideoOutputRequired = textureRenderMode == (int)VideoRecordingFrameLayout.Quad;
+                    }
                     FullScreenCompositorWindow fullscreenWindow = FullScreenCompositorWindow.TryGetWindow();
                     if (fullscreenWindow != null)
                     {
@@ -155,8 +159,8 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     {
                         bool wasEnabled = GUI.enabled;
                         GUI.enabled = compositionManager != null && !compositionManager.IsRecording();
-                        string[] compositionOptions = new string[] { "Final composited texture", "Quadrant with intermediate textures" };
-                        GUIContent renderingModeLabel = new GUIContent("Video recording texture", "Choose between displaying the composited video texture or seeing intermediate textures displayed in 4 sections (bottom left: input video, top left: opaque hologram, top right: hologram alpha mask, bottom right: hologram alpha-blended onto video)");
+                        string[] compositionOptions = new string[] { "Normal", "Split channels" };
+                        GUIContent renderingModeLabel = new GUIContent("Video output mode", "Choose between recording the composited video texture or recording intermediate textures displayed in 4 sections (bottom left: input video, top left: opaque hologram, top right: hologram alpha mask, bottom right: hologram alpha-blended onto video)");
                         compositionManager.VideoRecordingLayout = (VideoRecordingFrameLayout)EditorGUILayout.Popup(renderingModeLabel, (int)compositionManager.VideoRecordingLayout, compositionOptions);
                         GUI.enabled = wasEnabled;
                     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     textureRenderMode = EditorGUILayout.Popup(renderingModeLabel, textureRenderMode, compositionOptions);
                     if (compositionManager != null && compositionManager.TextureManager != null)
                     {
-                        compositionManager.TextureManager.IsQuadrantVideoOutputRequired = textureRenderMode == (int)VideoRecordingFrameLayout.Quad;
+                        compositionManager.TextureManager.IsQuadrantVideoFrameNeededForPreviewing = textureRenderMode == (int)VideoRecordingFrameLayout.Quad;
                     }
                     FullScreenCompositorWindow fullscreenWindow = FullScreenCompositorWindow.TryGetWindow();
                     if (fullscreenWindow != null)

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/HoloAlpha.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/HoloAlpha.shader
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+Shader "SV/HoloAlpha"
+{
+    Properties
+    {
+        _BackTex("BackTex", 2D) = "white" {}
+        _FronTex("FrontTex", 2D) = "white" {}
+        _Alpha("Alpha", float) = 0.9
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _BackTex;
+            sampler2D _FrontTex;
+            float _Alpha;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+            
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 backCol = tex2D(_BackTex, i.uv);
+                fixed4 frontCol = tex2D(_FrontTex, i.uv);
+            
+                fixed4 composite = backCol * (1 - _Alpha) + frontCol * _Alpha;
+                composite.a = 1.0f;
+                return composite;
+            }
+            ENDCG
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/HoloAlpha.shader.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/HoloAlpha.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c8a28ad8c8326d048a8a0af8fa87e004
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/README.md
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/README.md
@@ -72,9 +72,9 @@ The steps for connecting the Compositor to your application are the same as for 
 
 The **Recording** expander in the Compositor window can be used to start and stop recording or to take a still picture. Videos and pictures are saved in your Documents\HologramCapture directory. By default, audio from your computer's microphone will be recorded as part of the video.
 
-The **Video recording texture** option allows you to choose between recording only the final composited video or recording a split view with the original video, the opaque hologram without background, the alpha mask for the holograms, and the final composited video.
+The **Video output mode** option allows you to choose between **Normal** mode, which records only the final composited video, or **Split channels**, which records a split view with the original video, the opaque hologram without background, the alpha mask for the holograms, and the final composited video.
 
-The compositor also outputs video to your capture card (for cards that support output).
+The compositor also outputs video to your capture card (for cards that support output). The output to your video card is always the final composited video.
 
 ### Settings
 


### PR DESCRIPTION
The way that the "quad" view rendering works affects how transparency is handled for partially-transparent holograms. Previously, the rendering would:

1. Fill the camera's render texture with the real-world video
2. Unity renders holograms onto the real-world video
3. Re-draw the real-world video onto the resulting texture to create global hologram opacity

Because in this path the holograms are alpha-blended with the real-world background, their transparencies appear correct. This is what these intermediate textures look like.
![image](https://user-images.githubusercontent.com/10050922/62403525-a6a7e200-b542-11e9-9ecb-d46687ba2a2e.png)


The quadrant view approach works differently:
1. The camera is filled with black
2. Unity renders holograms onto the black texture
3. The holograms are blended with the real-world video using the alpha values from the resulting texture, including global hologram opacity

Because at step 2 the holograms are blended with black, they end up overall darker than if they'd been initially blended against the real-world video.  Here's a comparison in the same case as the previous image.

![image](https://user-images.githubusercontent.com/10050922/62403536-b9221b80-b542-11e9-81f2-95409bc8a416.png)

This PR restores using the original rendering path when not using quad video recording output. This allows for the majority of cases to have the more-correct alpha blending with the real world instead of with black. For the quadrant recording case, it is up to the end application to correctly handle alpha values of any partially-transparent holograms.