### PR TITLE
Add a flag for disabling the developer console

### DIFF
--- a/samples/Build2019Demo.Unity/Assets/Demo/Scenes/Finished_Scene.unity
+++ b/samples/Build2019Demo.Unity/Assets/Demo/Scenes/Finished_Scene.unity
@@ -258,6 +258,11 @@ PrefabInstance:
       propertyPath: debugLogging
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4941633254297953242, guid: aa311d939e452a045b897dcc7c9c36fb,
+        type: 3}
+      propertyPath: hideDeveloperConsole
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa311d939e452a045b897dcc7c9c36fb, type: 3}
 --- !u!1 &296902853

--- a/samples/Build2019Demo.Unity/Assets/Demo/Scenes/Finished_Scene.unity
+++ b/samples/Build2019Demo.Unity/Assets/Demo/Scenes/Finished_Scene.unity
@@ -248,6 +248,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4941633254297953242, guid: aa311d939e452a045b897dcc7c9c36fb,
+        type: 3}
+      propertyPath: hideDevelopmentConsole
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4941633254297953242, guid: aa311d939e452a045b897dcc7c9c36fb,
+        type: 3}
+      propertyPath: debugLogging
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa311d939e452a045b897dcc7c9c36fb, type: 3}
 --- !u!1 &296902853

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.HoloLens.unity
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.HoloLens.unity
@@ -467,6 +467,11 @@ PrefabInstance:
       propertyPath: hideDevelopmentConsole
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4941633254297953242, guid: aa311d939e452a045b897dcc7c9c36fb,
+        type: 3}
+      propertyPath: hideDeveloperConsole
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4941633254257257603, guid: aa311d939e452a045b897dcc7c9c36fb,
         type: 3}
       propertyPath: m_Enabled

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.HoloLens.unity
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scenes/SpectatorView.HoloLens.unity
@@ -462,6 +462,11 @@ PrefabInstance:
       propertyPath: debugLogging
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4941633254297953242, guid: aa311d939e452a045b897dcc7c9c36fb,
+        type: 3}
+      propertyPath: hideDevelopmentConsole
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4941633254257257603, guid: aa311d939e452a045b897dcc7c9c36fb,
         type: 3}
       propertyPath: m_Enabled

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
@@ -118,9 +118,9 @@ namespace Microsoft.MixedReality.SpectatorView
         [SerializeField]
         private bool debugLogging = false;
 
-        [Tooltip("Check to hide the development console every update.")]
+        [Tooltip("Check to hide the developer console every update.")]
         [SerializeField]
-        private bool hideDevelopmentConsole = false;
+        private bool hideDeveloperConsole = false;
 
         private GameObject settingsGameObject;
 
@@ -193,7 +193,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private void Update()
         {
-            if (hideDevelopmentConsole &&
+            if (hideDeveloperConsole &&
                 Debug.developerConsoleVisible)
             {
                 Debug.developerConsoleVisible = false;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.SpectatorView
         [SerializeField]
         private bool debugLogging = false;
 
-        [Tooltip("Check to hide the developer console every update.")]
+        [Tooltip("Check to hide the on-device developer console every update.")]
         [SerializeField]
         private bool hideDeveloperConsole = false;
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
@@ -118,6 +118,10 @@ namespace Microsoft.MixedReality.SpectatorView
         [SerializeField]
         private bool debugLogging = false;
 
+        [Tooltip("Check to hide the development console every update.")]
+        [SerializeField]
+        private bool hideDevelopmentConsole = false;
+
         private GameObject settingsGameObject;
 
 #if UNITY_ANDROID || UNITY_IOS
@@ -185,6 +189,15 @@ namespace Microsoft.MixedReality.SpectatorView
             }
 
             SetupRecordingService();
+        }
+
+        private void Update()
+        {
+            if (hideDevelopmentConsole &&
+                Debug.developerConsoleVisible)
+            {
+                Debug.developerConsoleVisible = false;
+            }
         }
 
         private void OnDestroy()


### PR DESCRIPTION
This pr addresses https://github.com/microsoft/MixedReality-SpectatorView/issues/98

This review contains the following:
1) hideDevelopmentConsole is added to the SpectatorView.cs script. When checked, SpectatorView checks whether the development console is visible every update. If the console is visible, its hidden. The default value for this is unchecked.
2) hideDevelopmentConsole is checked in SpectatorView.HoloLens.unity and Finished_Scene.unity. This results in the development console being hidden in our sample projects.

Note: The development console is still shown during the unity splash screen if any errors are encountered prior to Starting/Updating the SpectatorView prefab.