### PR TITLE
Fix text mesh pro synchronization logic and add troubleshooting step

### DIFF
--- a/doc/SpectatorView.Setup.md
+++ b/doc/SpectatorView.Setup.md
@@ -214,3 +214,6 @@ In some instances, file permissions may generate errors when opening a spectator
 The ARKit Camera has an Enable Auto Focus feature that consumes touch input events, breaking Unity canvas interactions on iOS. This can cause the Screen Recording UI to fail to show. To fix this, uncheck the `Enable Auto Focus` option for ARKit's `UnityARCameraManager`:
 
 ![Marker](images/iOSAutoFocus.png)
+
+### __Issue:__ Build errors occur when `STATESYNC_TEXTMESHPRO` is enabled
+In some instances, if your project does not use Unity 2018.3.14f1, you may encounter breaks in TextMeshPro state synchronization code. In most instances, you will need to make small, often type, fixes to get TextMeshPro synchronization correctly. For now, Spectator View supports Unity 2018.3.14f1 and the TextMeshPro code in the state synchronization code base will be built based off of the TextMeshPro packages shipped with Unity 2018.3.14f1.

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -101,7 +101,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 TextMeshObserver.fontSizeMax = message.ReadSingle();
                 TextMeshObserver.fontSizeMin = message.ReadSingle();
                 TextMeshObserver.fontStyle = (FontStyles)message.ReadInt32();
-                TextMeshObserver.fontWeight = (FontWeight)message.ReadInt32();
+                TextMeshObserver.fontWeight = message.ReadInt32();
                 TextMeshObserver.horizontalMapping = (TextureMappingOptions)message.ReadByte();
                 TextMeshObserver.lineSpacing = message.ReadSingle();
                 TextMeshObserver.lineSpacingAdjustment = message.ReadSingle();

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -104,7 +104,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 TextMeshObserver.fontSizeMax = message.ReadSingle();
                 TextMeshObserver.fontSizeMin = message.ReadSingle();
                 TextMeshObserver.fontStyle = (FontStyles)message.ReadInt32();
-                TextMeshObserver.fontWeight = (FontWeight) message.ReadInt32();
+                TextMeshObserver.fontWeight = (FontWeight)message.ReadInt32();
                 TextMeshObserver.horizontalMapping = (TextureMappingOptions)message.ReadByte();
                 TextMeshObserver.lineSpacing = message.ReadSingle();
                 TextMeshObserver.lineSpacingAdjustment = message.ReadSingle();

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -5,6 +5,9 @@ using System.IO;
 
 #if STATESYNC_TEXTMESHPRO
 using TMPro;
+#if !(UNITY_2018_4_OR_NEWER)
+using FontWeight = System.Int32;
+#endif
 #else
 using System;
 #endif
@@ -101,7 +104,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 TextMeshObserver.fontSizeMax = message.ReadSingle();
                 TextMeshObserver.fontSizeMin = message.ReadSingle();
                 TextMeshObserver.fontStyle = (FontStyles)message.ReadInt32();
-                TextMeshObserver.fontWeight = message.ReadInt32();
+                TextMeshObserver.fontWeight = (FontWeight) message.ReadInt32();
                 TextMeshObserver.horizontalMapping = (TextureMappingOptions)message.ReadByte();
                 TextMeshObserver.lineSpacing = message.ReadSingle();
                 TextMeshObserver.lineSpacingAdjustment = message.ReadSingle();


### PR DESCRIPTION
1) A change went in that fixed text mesh pro for a version of Unity that isn't the formal supported for Spectator View. A cast is removed that fixes things.
2) We added a troubleshooting step to documentation to call out these sorts of issues.