### PR TITLE
Enable nightly builds

### DIFF
--- a/tools/ci/ci-nightly.yaml
+++ b/tools/ci/ci-nightly.yaml
@@ -1,10 +1,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-# MixedReality-SpectatorView build native content
+# MixedReality-SpectatorView nightly build
 
-# Scheduled run, always run to monitor churn in external dependencies
-schedules:
+# Give a unique name to the build each time it runs
+name: ci-nightly-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
+
+variables:
+  UnityVersion: Unity2018.3.7f1
+
+# Trigger CI on nightly schedule
 - cron: "0 0 * * *"
   displayName: Daily Midnight Build
   branches:
@@ -12,17 +17,11 @@ schedules:
     - master
   always: true
 
-# Trigger CI on push changes
+# Do not trigger CI on pushed changes
 trigger: none
 
 # Do not trigger CI on PRs
 pr: none
-
-# Give a unique name to the build each time it runs
-name: ci-nightly-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
-
-variables:
-  UnityVersion: Unity2018.3.7f1
 
 jobs:
 - job: BuildNativeComponents

--- a/tools/ci/ci-nightly.yaml
+++ b/tools/ci/ci-nightly.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for license information.
+
+# MixedReality-SpectatorView build native content
+
+# Scheduled run, always run to monitor churn in external dependencies
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily Midnight Build
+  branches:
+    include:
+    - master
+  always: true
+
+# Trigger CI on push changes
+trigger: none
+
+# Do not trigger CI on PRs
+pr: none
+
+# Give a unique name to the build each time it runs
+name: ci-native-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
+
+variables:
+  UnityVersion: Unity2018.3.7f1
+
+jobs:
+- job: BuildNativeComponents
+  timeoutInMinutes: 90
+  pool:
+    name: On-Prem Unity
+    demands:
+    - SDK_18362 -equals TRUE
+  steps:
+  - task: UniversalPackages@0
+    displayName: 'Download Native Dependencies'
+    inputs:
+      command: download
+      vstsFeed: $(DependencyFeed)
+      vstsFeedPackage: $(DependencyPackage)
+      vstsPackageVersion: $(DependencyVersion)
+      downloadDirectory: 'external\dependencies'
+  - template: templates\buildnative.yml

--- a/tools/ci/ci-nightly.yaml
+++ b/tools/ci/ci-nightly.yaml
@@ -19,7 +19,7 @@ trigger: none
 pr: none
 
 # Give a unique name to the build each time it runs
-name: ci-native-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
+name: ci-nightly-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
 
 variables:
   UnityVersion: Unity2018.3.7f1


### PR DESCRIPTION
This duplicates our existing ci-native.yam template to create a nightly build.