### PR TITLE
Fix bad transform calculation

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateTransformer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateTransformer.cs
@@ -53,9 +53,20 @@ namespace Microsoft.MixedReality.SpectatorView
                 var peerCoordinateToWorldRotation = currentParticipant.PeerSpatialCoordinateWorldRotation;
 
                 // Create a transform that converts the local world space to the peer world space (peer coordinate to peer world * local world to local shared coordinate).
-                sharedCoordinateOrigin.position = peerCoordinateToWorldPosition + localWorldToCoordinatePosition;
-                sharedCoordinateOrigin.rotation = peerCoordinateToWorldRotation * localWorldToCoordinateRotation;
-                DebugLog($"Updated transform, Position: {sharedCoordinateOrigin.position.ToString("G4")}, Rotation: {sharedCoordinateOrigin.rotation.ToString("G4")}");
+                var matrix = Matrix4x4.TRS(peerCoordinateToWorldPosition, peerCoordinateToWorldRotation, Vector3.one) * Matrix4x4.TRS(localWorldToCoordinatePosition, localWorldToCoordinateRotation, Vector3.one);
+                Vector3 position = matrix.GetColumn(3);
+                var rotation = Quaternion.LookRotation(matrix.GetColumn(2), matrix.GetColumn(1));
+
+                if (sharedCoordinateOrigin.position != position ||
+                    sharedCoordinateOrigin.rotation != rotation)
+                {
+                    DebugLog($"World To Coordinate, Position:{localWorldToCoordinatePosition.ToString("G4")}, Rotation:{localWorldToCoordinateRotation.ToString("G4")}");
+                    DebugLog($"Peer Coordinate To World, Position:{peerCoordinateToWorldPosition.ToString("G4")}, Rotation:{peerCoordinateToWorldRotation.ToString("G4")}");
+
+                    sharedCoordinateOrigin.rotation = rotation;
+                    sharedCoordinateOrigin.position = position;
+                    DebugLog($"Updated transform, Position: {sharedCoordinateOrigin.position.ToString("G4")}, Rotation: {sharedCoordinateOrigin.rotation.ToString("G4")}");
+                }
             }
         }
 


### PR DESCRIPTION
I'm not sure at what point this broken transform got introduced. It wasn't immediately obvious that things were wrong if you setup the shared spatial coordinate system while the mobile device's camera was close to its local origin.

Tested against the Build 2019 (using ASA) and Example (using qr code) solutions.