### PR TITLE
Add Unity Editor window for assessing existing state synchronization performance parameters

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CalibrationTestWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CalibrationTestWindow.cs
@@ -157,7 +157,13 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                         EditorGUILayout.BeginVertical("Box", GUILayout.MinHeight(250.0f));
                         {
                             var cameraDevice = GetHolographicCameraDevice();
-                            HolographicCameraNetworkConnectionGUI(HolographicCameraDeviceTypeLabel, cameraDevice, GetSpatialCoordinateSystemParticipant(cameraDevice), showCalibrationStatus: false, ref holographicCameraIPAddress);
+                            HolographicCameraNetworkConnectionGUI(
+                                HolographicCameraDeviceTypeLabel,
+                                cameraDevice,
+                                GetSpatialCoordinateSystemParticipant(cameraDevice),
+                                showCalibrationStatus: false,
+                                showSpatialLocalization: true,
+                                ref holographicCameraIPAddress);
 
                             GUILayout.FlexibleSpace();
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -89,8 +89,20 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 }
                 DeviceInfoObserver holographicCameraDevice = GetHolographicCameraDevice();
 
-                HolographicCameraNetworkConnectionGUI(AppDeviceTypeLabel, stateSynchronizationDevice, GetSpatialCoordinateSystemParticipant(stateSynchronizationDevice), showCalibrationStatus: false, ref appIPAddress);
-                HolographicCameraNetworkConnectionGUI(HolographicCameraDeviceTypeLabel, holographicCameraDevice, GetSpatialCoordinateSystemParticipant(holographicCameraDevice), showCalibrationStatus: true, ref holographicCameraIPAddress);
+                HolographicCameraNetworkConnectionGUI(
+                    AppDeviceTypeLabel,
+                    stateSynchronizationDevice,
+                    GetSpatialCoordinateSystemParticipant(stateSynchronizationDevice),
+                    showCalibrationStatus: false,
+                    showSpatialLocalization: true,
+                    ref appIPAddress);
+                HolographicCameraNetworkConnectionGUI(
+                    HolographicCameraDeviceTypeLabel,
+                    holographicCameraDevice,
+                    GetSpatialCoordinateSystemParticipant(holographicCameraDevice),
+                    showCalibrationStatus: true,
+                    showSpatialLocalization: true,
+                    ref holographicCameraIPAddress);
             }
             EditorGUILayout.EndHorizontal();
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             PlayerPrefs.Save();
         }
 
-        protected void HolographicCameraNetworkConnectionGUI(string deviceTypeLabel, DeviceInfoObserver deviceInfo, SpatialCoordinateSystemParticipant spatialCoordinateSystemParticipant, bool showCalibrationStatus, ref string ipAddressField)
+        protected void HolographicCameraNetworkConnectionGUI(string deviceTypeLabel, DeviceInfoObserver deviceInfo, SpatialCoordinateSystemParticipant spatialCoordinateSystemParticipant, bool showCalibrationStatus, bool showSpatialLocalization, ref string ipAddressField)
         {
             GUIStyle boldLabelStyle = new GUIStyle(GUI.skin.label);
             boldLabelStyle.fontStyle = FontStyle.Bold;
@@ -123,8 +123,11 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     sharedSpatialCoordinateStatusMessage = locatedSharedSpatialCoordinateMessage;
                 }
 
-                GUILayout.Label("Shared spatial coordinate status", boldLabelStyle);
-                GUILayout.Label(sharedSpatialCoordinateStatusMessage);
+                if (showSpatialLocalization)
+                {
+                    GUILayout.Label("Shared spatial coordinate status", boldLabelStyle);
+                    GUILayout.Label(sharedSpatialCoordinateStatusMessage);
+                }
 
                 string calibrationStatusMessage;
                 if (compositionManager != null && compositionManager.IsCalibrationDataLoaded)
@@ -149,13 +152,16 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     GUILayout.Label(string.Empty);
                 }
 
-                EditorGUILayout.Space();
+                if (showSpatialLocalization)
+                {
+                    EditorGUILayout.Space();
 
-                GUILayout.Label("Spatial Alignment", boldLabelStyle);
+                    GUILayout.Label("Spatial Alignment", boldLabelStyle);
 
-                GUILayout.Space(4);
+                    GUILayout.Space(4);
 
-                SpatialLocalizationGUI(deviceTypeLabel, spatialCoordinateSystemParticipant);
+                    SpatialLocalizationGUI(deviceTypeLabel, spatialCoordinateSystemParticipant);
+                }
 
                 GUI.enabled = true;
             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationMenuItems.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationMenuItems.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         }
 
         [MenuItem("Spectator View/Edit Global Performance Parameters", priority = 200)]
-        private static void EditGlobalPerformanceParameters()
+        internal static void EditGlobalPerformanceParameters()
         {
             GameObject prefab = Resources.Load<GameObject>(StateSynchronizationSceneManager.DefaultStateSynchronizationPerformanceParametersPrefabName);
             if (prefab == null)

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
     {
         private static readonly string appIPAddressKey = $"{nameof(StateSynchronizationPerformanceWindow)}.{nameof(appIPAddress)}";
         private string appIPAddress;
-        private const int globalSettingsButtonWidth = 180;
+        private const int globalSettingsButtonWidth = 220;
         private Vector2 scrollPosition;
 
         [MenuItem("Spectator View/Performance", false, 3)]
@@ -37,7 +37,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         {
             EditorGUILayout.BeginVertical();
             {
-                if (GUILayout.Button(new GUIContent("Open settings prefab", "Opens the prefab that defines global performance settings."), GUILayout.Width(globalSettingsButtonWidth)))
+                if (GUILayout.Button(new GUIContent("Open performance settings prefab", "Opens the prefab that defines global performance settings."), GUILayout.Width(globalSettingsButtonWidth)))
                 {
                     StateSynchronizationMenuItems.EditGlobalPerformanceParameters();
                 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
@@ -4,6 +4,7 @@
 using UnityEngine;
 using UnityEditor;
 using System.ComponentModel;
+using System.Collections.Generic;
 
 namespace Microsoft.MixedReality.SpectatorView.Editor
 {
@@ -44,8 +45,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
                 if (!EditorApplication.isPlaying)
                 {
-                    var observer = FindObjectOfType<StateSynchronizationObserver>();
-                    if (observer == null)
+                    if (StateSynchronizationObserver.Instance == null)
                     {
                         RenderTitle("StateSynchronizationObserver was not detected in the current scene. Open the SpectatorViewCompositor scene.", Color.red);
                     }
@@ -89,13 +89,13 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             }
             else
             {
-                RenderTitle("Performance information", Color.green);
+                RenderTitle("HoloLens application performance information", Color.green);
                 scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
-                byte index = 0;
-                foreach (var time in StateSynchronizationObserver.Instance.AverageTimePerFeature)
+                IReadOnlyList<double> times = StateSynchronizationObserver.Instance.AverageTimePerFeature;
+                for (int i = 0; i < times.Count; i++)
                 {
-                    GUILayout.Label($"Feature {(StateSynchronizationPerformanceFeature)index}:{time.ToString("G4")}");
-                    index++;
+                    double time = times[i];
+                    GUILayout.Label($"Feature {(StateSynchronizationPerformanceFeature)i}:{time.ToString("G4")}");
                 }
                 EditorGUILayout.EndScrollView();
             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEditor;
+using System.ComponentModel;
+
+namespace Microsoft.MixedReality.SpectatorView.Editor
+{
+    [Description("Performance")]
+    internal class StateSynchronizationPerformanceWindow : CompositorWindowBase<StateSynchronizationPerformanceWindow>
+    {
+        private static readonly string appIPAddressKey = $"{nameof(StateSynchronizationPerformanceWindow)}.{nameof(appIPAddress)}";
+        private string appIPAddress;
+        private const int globalSettingsButtonWidth = 180;
+        private Vector2 scrollPosition;
+
+        [MenuItem("Spectator View/Performance", false, 3)]
+        public static void ShowCalibrationRecordingWindow()
+        {
+            ShowWindow();
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            appIPAddress = PlayerPrefs.GetString(appIPAddressKey, "localhost");
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            PlayerPrefs.SetString(appIPAddressKey, appIPAddress);
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.BeginVertical();
+            {
+                if (GUILayout.Button(new GUIContent("Open settings prefab", "Opens the prefab that defines global performance settings."), GUILayout.Width(globalSettingsButtonWidth)))
+                {
+                    StateSynchronizationMenuItems.EditGlobalPerformanceParameters();
+                }
+
+                if (!EditorApplication.isPlaying)
+                {
+                    var observer = FindObjectOfType<StateSynchronizationObserver>();
+                    if (observer == null)
+                    {
+                        RenderTitle("StateSynchronizationObserver was not detected in the current scene. Open the SpectatorViewCompositor scene.", Color.red);
+                    }
+                    else
+                    {
+                        RenderTitle("Enter playmode to view performance information.", Color.gray);
+                    }
+                }
+                else if (EditorApplication.isPlaying &&
+                    !StateSynchronizationObserver.IsInitialized)
+                {
+                    RenderTitle("StateSynchronizationObserver was not detected in the current scene. Open SpectatorViewCompositor", Color.red);
+                }
+                else
+                {
+                    UpdatePerformanceInformation();
+                }
+            }
+            EditorGUILayout.EndVertical();
+        }
+
+        private void UpdatePerformanceInformation()
+        {
+            DeviceInfoObserver stateSynchronizationDevice = null;
+            if (StateSynchronizationObserver.IsInitialized)
+            {
+                stateSynchronizationDevice = StateSynchronizationObserver.Instance.GetComponent<DeviceInfoObserver>();
+            }
+
+            HolographicCameraNetworkConnectionGUI(
+                AppDeviceTypeLabel,
+                stateSynchronizationDevice,
+                GetSpatialCoordinateSystemParticipant(stateSynchronizationDevice),
+                showCalibrationStatus: false,
+                showSpatialLocalization: false,
+                ref appIPAddress);
+
+            if (StateSynchronizationObserver.Instance.PerformanceFeatureCount == 0)
+            {
+                RenderTitle("Waiting for performance information...", Color.yellow);
+            }
+            else
+            {
+                RenderTitle("Performance information", Color.green);
+                scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
+                byte index = 0;
+                foreach (var time in StateSynchronizationObserver.Instance.AverageTimePerFeature)
+                {
+                    GUILayout.Label($"Feature {(StateSynchronizationPerformanceFeature)index}:{time.ToString("G4")}");
+                    index++;
+                }
+                EditorGUILayout.EndScrollView();
+            }
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d41620e6897e224e972d1f91f20c1bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationBroadcaster.cs
@@ -187,8 +187,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 using (MemoryStream memoryStream = new MemoryStream())
                 using (BinaryWriter message = new BinaryWriter(memoryStream))
                 {
-                    message.Write("Perf");
-
+                    message.Write(StateSynchronizationObserver.PerfCommand);
                     StateSynchronizationPerformanceMonitor.Instance.WriteMessage(message);
                     message.Flush();
                     connectionManager.Broadcast(memoryStream.ToArray());

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationPerformanceMonitor.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationPerformanceMonitor.cs
@@ -13,12 +13,13 @@ namespace Microsoft.MixedReality.SpectatorView
         GameObjectComponentCheck = 0x0,
         MaterialPropertyUpdate = 0x1,
         MaterialPropertyBlockUpdate = 0x2,
+        Count = 0x3
     }
 
     internal class StateSynchronizationPerformanceMonitor : Singleton<StateSynchronizationPerformanceMonitor>
     {
         private const int PeriodsToAverageOver = 5;
-        private const int FeatureCount = 3;
+        private const int FeatureCount = (int)StateSynchronizationPerformanceFeature.Count;
         private Stopwatch[] stopwatches;
         private float[][] previousSpentTimes;
         private float[][] previousActualTimes;


### PR DESCRIPTION
SpectatorView contains some logic for monitoring performance information/tinkering with what items are synchronized. This review adds a window to the Unity editor that allow viewing application performance stats.

Contents of pull request:
1) A StateSynchronizationPerformanceWindow has been added to the in editor SpectatorView UI. This UI allows viewing time costs for assessing game object components and material properties. It also has a button for opening the state synchronization performance prefab, which allows for greater performance tinkering.