### PR TITLE
Ensure that the TransformBroadcaster is not destroyed early

### DIFF
--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/Android.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/Android.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 25dc6c45223131d4096ca32f4a621944
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/iOS.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/iOS.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0689cfa8a1163e941ae9f20532b25e72
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationBroadcaster.cs
@@ -210,6 +210,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private void HandleAssetBundleRequestInfo(SocketEndpoint endpoint, string command, BinaryReader reader, int remainingDataSize)
         {
             AssetBundlePlatform platform = (AssetBundlePlatform)reader.ReadByte();
+            DebugLog($"Received asset bundle info request for platform {platform}");
             TextAsset asset = Resources.Load<TextAsset>($"{platform.ToString()}/spectatorview");
             bool hasAsset = asset != null;
 
@@ -249,6 +250,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private void HandleAssetLoadCompleted(SocketEndpoint endpoint, string command, BinaryReader reader, int remainingDataSize)
         {
+            DebugLog("Asset loading is complete, sending the ConnectedAndReady event");
+
             // Notify everyone the connection is actually ready
             ConnectedAndReady?.Invoke(endpoint);
         }


### PR DESCRIPTION
Currently there's a new phase of asset bundle negotiation that happens before content is synchronized. When using a GameObjectHierarchyBroadcaster, a TransformBroadcaster is created upon connect. This TransformBroadcaster should not be destroyed during the negotiation period, so I've now kept a set of pending connections that can be used to determine if there are any potential connections forming.