### PR TITLE
Reshow the network connection dialogue on a network disconnect

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/SocketEndpoint.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/SocketEndpoint.cs
@@ -89,6 +89,14 @@ namespace Microsoft.MixedReality.SpectatorView
         }
 
         /// <summary>
+        /// Call to prevent additional attempts at connecting. Note: if no connection has been established, calling this function will prevent establishing a connection.
+        /// </summary>
+        public void StopConnectionAttempts()
+        {
+            socketerClient.StopConnectionAttempts();
+        }
+
+        /// <summary>
         /// Call to send data to this endpoint
         /// </summary>
         /// <param name="data">data to send</param>

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/SocketerClient.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/SocketerClient.cs
@@ -564,7 +564,7 @@ namespace Microsoft.MixedReality.SpectatorView
             private bool threadShouldRun;
             // If a connection fails, wait this many ms
             private const int timeoutMS = 500;
-            private bool attemptConnection = true;
+            private volatile bool attemptConnection = true;
 
             internal class ConnectionEventArgs : EventArgs
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/SocketerClient.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/SocketerClient.cs
@@ -267,6 +267,17 @@ namespace Microsoft.MixedReality.SpectatorView
         }
 
         /// <summary>
+        /// Call to prevent additional attempts at connecting. Note: if no connection has been established, calling this function will prevent establishing a connection.
+        /// </summary>
+        public void StopConnectionAttempts()
+        {
+            if (tcpClient != null)
+            {
+                tcpClient.StopConnectionAttempts();
+            }
+        }
+
+        /// <summary>
         /// Sends a string to the other side.  Works for all Socketers except UDP Listeners.
         /// If the other Socketer is not listening, the messages are lost.
         /// </summary>
@@ -553,6 +564,7 @@ namespace Microsoft.MixedReality.SpectatorView
             private bool threadShouldRun;
             // If a connection fails, wait this many ms
             private const int timeoutMS = 500;
+            private bool attemptConnection = true;
 
             internal class ConnectionEventArgs : EventArgs
             {
@@ -694,6 +706,10 @@ namespace Microsoft.MixedReality.SpectatorView
                 }
             }
 
+            public void StopConnectionAttempts()
+            {
+                attemptConnection = false;
+            }
 
             private bool Connect()
             {
@@ -792,10 +808,19 @@ namespace Microsoft.MixedReality.SpectatorView
                 {
                     if (!IsConnected)
                     {
-                        Debug.Log("Trying to connect to " + host + ":" + port);
-                        if (!Connect())
+                        if (attemptConnection)
                         {
-                            Thread.Sleep(timeoutMS);
+                            Debug.Log("Trying to connect to " + host + ":" + port);
+                            if (!Connect())
+                            {
+                                Thread.Sleep(timeoutMS);
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            Debug.Log("SocketClient was disconnected. Reconnect won't be attempted.");
+                            this.Stop();
                             continue;
                         }
                     }
@@ -978,6 +1003,11 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 shouldConnect = false;
                 Disconnect();
+            }
+
+            public void StopConnectionAttempts()
+            {
+                shouldConnect = false;
             }
 
             public void Disconnect()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/TCPConnectionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/TCPConnectionManager.cs
@@ -24,6 +24,10 @@ namespace Microsoft.MixedReality.SpectatorView
         /// Called when a data payload is received
         /// </summary>
         public event Action<IncomingMessage> OnReceive;
+        /// <summary>
+        /// If true, socket clients will attempt to reconnect when disconnected.
+        /// </summary>
+        public bool AttemptReconnectWhenClient = true;
 
         private readonly TimeSpan timeoutInterval = TimeSpan.Zero;
         private readonly ConcurrentQueue<SocketEndpoint> newConnections = new ConcurrentQueue<SocketEndpoint>();
@@ -128,6 +132,12 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             Debug.Log("Client connected to " + hostAddress);
             SocketEndpoint socketEndpoint = new SocketEndpoint(client, timeoutInterval, hostAddress, sourceId);
+
+            if (!AttemptReconnectWhenClient)
+            {
+                socketEndpoint.StopConnectionAttempts();
+            }
+
             clientConnection = socketEndpoint;
             socketEndpoint.QueueIncomingMessages(inputMessageQueue);
             newConnections.Enqueue(socketEndpoint);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkManager.cs
@@ -14,6 +14,13 @@ namespace Microsoft.MixedReality.SpectatorView
         [SerializeField]
         protected TCPConnectionManager connectionManager = null;
 
+        public bool AttemptReconnectWhenClient
+        {
+            get { return attemptReconnectWhenClient; }
+            set { attemptReconnectWhenClient = value; }
+        }
+        private bool attemptReconnectWhenClient = true;
+
         private SocketEndpoint currentConnection;
 
         /// <inheritdoc />
@@ -57,6 +64,7 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             if (connectionManager != null)
             {
+                connectionManager.AttemptReconnectWhenClient = AttemptReconnectWhenClient;
                 connectionManager.ConnectTo(ipAddress, port);
             }
             else


### PR DESCRIPTION
This pull request addresses https://github.com/microsoft/MixedReality-SpectatorView/issues/133

In this change:
1) A method is exposed on SocketClient that can be called to set a flag that prevents any additional connection attempts.
2) A flag is exposed on SpectatorView.cs that allows users to choose whether to automatically attempt reconnects when running as spectators.

Observed when working on this change: https://github.com/microsoft/MixedReality-SpectatorView/issues/242