### PR TITLE
Clean up the generated folder assets when building asset bundle

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationMenuItems.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationMenuItems.cs
@@ -118,15 +118,23 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             foreach (var directory in builtDirectories)
             {
                 string assetPath = $"{directory}/spectatorview".Replace('/', Path.DirectorySeparatorChar);
-                string resourcePath = $"{directory}/{ResourcesDirectoryName}".Replace('/', Path.DirectorySeparatorChar);
+                string resourcePath = $"{directory}/{Path.GetFileName(directory)}".Replace('/', Path.DirectorySeparatorChar);
 
                 File.Delete(resourcePath);
                 File.Delete($"{resourcePath}.manifest");
+
                 File.Delete($"{assetPath}.bytes");
                 File.Delete($"{assetPath}.manifest.bytes");
 
-                File.Move(assetPath, $"{assetPath}.bytes");
-                File.Move($"{assetPath}.manifest", $"{assetPath}.manifest.bytes");
+                if (File.Exists(assetPath))
+                {
+                    File.Move(assetPath, $"{assetPath}.bytes");
+                    File.Move($"{assetPath}.manifest", $"{assetPath}.manifest.bytes");
+                }
+                else
+                {
+                    Debug.LogError($"Expected that asset bundle {assetPath} was generated, but it does not exist");
+                }
             }
         }
 


### PR DESCRIPTION
This commit makes sure the directory-named files that the asset bundle generator creates get deleted, and that an error is emitted if the asset bundle that should be generated does not get created.