### PR TITLE
Make sure that every asset cache is assigned to the SpectatorView asset bundle

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.SpectatorView
     internal abstract class AssetCache : ScriptableObject
     {
         public const string assetCacheDirectory = "Generated.StateSynchronization.AssetCaches";
+        private const string spectatorViewAssetBundleName = "SpectatorView";
 
         protected static TAssetCache LoadAssetCache<TAssetCache>()
             where TAssetCache : AssetCache
@@ -56,11 +57,17 @@ namespace Microsoft.MixedReality.SpectatorView
                 EnsureAssetDirectoryExists();
 
                 AssetDatabase.CreateAsset(asset, assetPathAndName);
-
-                var importer = AssetImporter.GetAtPath(assetPathAndName);
-                importer.assetBundleName = "SpectatorView";
-                importer.SaveAndReimport();
             }
+
+            var importer = AssetImporter.GetAtPath(assetPathAndName);
+            if (importer.assetBundleName != spectatorViewAssetBundleName)
+            {
+                importer.assetBundleName = spectatorViewAssetBundleName;
+                importer.SaveAndReimport();
+
+                asset = AssetDatabase.LoadAssetAtPath<TAssetCache>(assetPathAndName);
+            }
+
             return asset;
 #else
             return LoadAssetCache<TAssetCache>();


### PR DESCRIPTION
This change makes sure that each asset cache is assigned to the SpectatorView asset bundle when running Update All Asset Caches, even if those asset caches previously existed or were reassigned to a different bundle.