### PR TITLE
Enable cancelling localization sessions

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsAndroidCoordinateService.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsAndroidCoordinateService.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.SpatialAlignment
     internal class SpatialAnchorsAndroidCoordinateService : SpatialAnchorsCoordinateService
     {
         private long lastFrameProcessedTimeStamp;
+        private static bool initialized = false;
 
         /// <summary>
         /// Instantiates a new <see cref="SpatialAnchorsAndroidCoordinateService"/>.
@@ -30,16 +31,31 @@ namespace Microsoft.MixedReality.SpatialAlignment
         /// <inheritdoc/>
         protected override Task OnInitializeAsync()
         {
+            if (initialized)
+            {
+                Debug.Log("SpatialAnchorsAndroidCoordinateService: session already initialized");
+                return Task.CompletedTask;
+            }
+
             TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
 
             UnityAndroidHelper.Instance.DispatchUiThread(unityActivity =>
             {
+                if (initialized)
+                {
+                    Debug.Log("SpatialAnchorsAndroidCoordinateService: session already initialized");
+                    taskCompletionSource.SetResult(null);
+                    return;
+                }
+
                 try
                 {
                     // We should only run the java initialization once
                     using (AndroidJavaClass cloudServices = new AndroidJavaClass("com.microsoft.CloudServices"))
                     {
                         cloudServices.CallStatic("initialize", unityActivity);
+                        Debug.Log("SpatialAnchorsAndroidCoordinateService: session successfully initialized");
+                        initialized = true;
                         taskCompletionSource.SetResult(null);
                     }
                 }

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsCoordinateService.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsCoordinateService.cs
@@ -324,6 +324,11 @@ namespace Microsoft.MixedReality.SpatialAlignment
                     await session.CreateAnchorAsync(cloudSpatialAnchor);
                     return new SpatialAnchorsCoordinate(cloudSpatialAnchor, spawnedAnchorObject);
                 }
+                catch(TaskCanceledException)
+                {
+                    Debug.Log("Create coordinate was cancelled.");
+                    UnityEngine.Object.Destroy(spawnedAnchorObject);
+                }
                 catch
                 {
                     UnityEngine.Object.Destroy(spawnedAnchorObject);
@@ -334,6 +339,8 @@ namespace Microsoft.MixedReality.SpatialAlignment
             {
                 ReleaseSessionStartRequest();
             }
+
+            return null;
         }
 
         private async Task<ISpatialCoordinate> TryCreateCoordinateEditorAsync(Vector3 worldPosition, Quaternion worldRotation, CancellationToken cancellationToken)

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsCoordinateService.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsCoordinateService.cs
@@ -324,11 +324,6 @@ namespace Microsoft.MixedReality.SpatialAlignment
                     await session.CreateAnchorAsync(cloudSpatialAnchor);
                     return new SpatialAnchorsCoordinate(cloudSpatialAnchor, spawnedAnchorObject);
                 }
-                catch(TaskCanceledException)
-                {
-                    Debug.Log("Create coordinate was cancelled.");
-                    UnityEngine.Object.Destroy(spawnedAnchorObject);
-                }
                 catch
                 {
                     UnityEngine.Object.Destroy(spawnedAnchorObject);

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsCoordinateService.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpatialAlignment/SpatialAnchorsCoordinateService.cs
@@ -334,8 +334,6 @@ namespace Microsoft.MixedReality.SpatialAlignment
             {
                 ReleaseSessionStartRequest();
             }
-
-            return null;
         }
 
         private async Task<ISpatialCoordinate> TryCreateCoordinateEditorAsync(Vector3 worldPosition, Quaternion worldRotation, CancellationToken cancellationToken)

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
@@ -92,6 +92,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private class SpatialCoordinateLocalizationSession : SpatialLocalizationSession
         {
+            /// <inheritdoc/>
             public override IPeerConnection Peer => peerConnection;
 
             private readonly IPeerConnection peerConnection;
@@ -116,10 +117,11 @@ namespace Microsoft.MixedReality.SpectatorView
                 coordinateService.FrameUpdate();
             }
 
+            /// <inheritdoc/>
             public override async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
             {
                 ISpatialCoordinate coordinateToReturn = null;
-                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCancellationToken, cancellationToken))
                 {
                     if (configuration.IsCoordinateCreator)
                     {
@@ -164,6 +166,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 return coordinateToReturn;
             }
 
+            /// <inheritdoc/>
             protected override void OnManagedDispose()
             {
                 base.OnManagedDispose();
@@ -172,6 +175,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 localizer.Updated -= OnUpdated;
             }
 
+            /// <inheritdoc/>
             public override void OnDataReceived(BinaryReader reader)
             {
                 coordinateIdentifierTaskSource.TrySetResult(reader.ReadString());

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.SpectatorView
             private readonly SpatialAnchorsLocalizer localizer;
             private readonly TaskCompletionSource<string> coordinateIdentifierTaskSource;
 
-            public SpatialCoordinateLocalizationSession(SpatialAnchorsLocalizer localizer, SpatialAnchorsCoordinateService coordinateService, SpatialAnchorsConfiguration configuration, IPeerConnection peerConnection)
+            public SpatialCoordinateLocalizationSession(SpatialAnchorsLocalizer localizer, SpatialAnchorsCoordinateService coordinateService, SpatialAnchorsConfiguration configuration, IPeerConnection peerConnection) : base()
             {
                 this.localizer = localizer;
                 this.coordinateService = coordinateService;
@@ -125,11 +125,17 @@ namespace Microsoft.MixedReality.SpectatorView
                     {
                         localizer.DebugLog("User getting initialized coordinate");
                         coordinateToReturn = await coordinateService.TryCreateCoordinateAsync(localizer.anchorPosition, Quaternion.Euler(localizer.anchorRotation), cancellableCTS.Token);
-
-                        localizer.DebugLog($"Sending coordinate id: {coordinateToReturn.Id}");
-                        peerConnection.SendData(writer => writer.Write(coordinateToReturn.Id));
-
-                        localizer.DebugLog("Message sent.");
+                        if (coordinateToReturn != null)
+                        {                           
+                            localizer.DebugLog($"Sending coordinate id: {coordinateToReturn.Id}");
+                            peerConnection.SendData(writer => writer.Write(coordinateToReturn.Id));
+                            localizer.DebugLog("Message sent.");
+                        }
+                        else
+                        {
+                            Debug.LogError("Coordinate discovery returned null coordinate");
+                            return null;
+                        }
                     }
                     else
                     {

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
@@ -90,9 +90,9 @@ namespace Microsoft.MixedReality.SpectatorView
             Updated?.Invoke();
         }
 
-        private class SpatialCoordinateLocalizationSession : DisposableBase, ISpatialLocalizationSession
+        private class SpatialCoordinateLocalizationSession : SpatialLocalizationSession
         {
-            public IPeerConnection Peer => peerConnection;
+            public override IPeerConnection Peer => peerConnection;
 
             private readonly IPeerConnection peerConnection;
             private readonly SpatialAnchorsCoordinateService coordinateService;
@@ -116,38 +116,41 @@ namespace Microsoft.MixedReality.SpectatorView
                 coordinateService.FrameUpdate();
             }
 
-            public async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
+            public override async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
             {
                 ISpatialCoordinate coordinateToReturn = null;
-                if (configuration.IsCoordinateCreator)
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
                 {
-                    localizer.DebugLog("User getting initialized coordinate");
-                    coordinateToReturn = await coordinateService.TryCreateCoordinateAsync(localizer.anchorPosition, Quaternion.Euler(localizer.anchorRotation), cancellationToken);
-
-                    localizer.DebugLog($"Sending coordinate id: {coordinateToReturn.Id}");
-                    peerConnection.SendData(writer => writer.Write(coordinateToReturn.Id));
-
-                    localizer.DebugLog("Message sent.");
-                }
-                else
-                {
-                    localizer.DebugLog("Non-host waiting for coord id to be sent over");
-                    string coordinateIdentifier = await coordinateIdentifierTaskSource.Task.Unless(cancellationToken);
-
-                    if (!cancellationToken.IsCancellationRequested)
+                    if (configuration.IsCoordinateCreator)
                     {
-                        localizer.DebugLog($"Coordinate id: {coordinateIdentifier}, starting discovery.");
-                        if (await coordinateService.TryDiscoverCoordinatesAsync(cancellationToken, coordinateIdentifier))
+                        localizer.DebugLog("User getting initialized coordinate");
+                        coordinateToReturn = await coordinateService.TryCreateCoordinateAsync(localizer.anchorPosition, Quaternion.Euler(localizer.anchorRotation), cancellableCTS.Token);
+
+                        localizer.DebugLog($"Sending coordinate id: {coordinateToReturn.Id}");
+                        peerConnection.SendData(writer => writer.Write(coordinateToReturn.Id));
+
+                        localizer.DebugLog("Message sent.");
+                    }
+                    else
+                    {
+                        localizer.DebugLog("Non-host waiting for coord id to be sent over");
+                        string coordinateIdentifier = await coordinateIdentifierTaskSource.Task.Unless(cancellableCTS.Token);
+
+                        if (!cancellableCTS.Token.IsCancellationRequested)
                         {
-                            localizer.DebugLog("Discovery complete, retrieving reference to ISpatialCoordinate");
-                            if (!coordinateService.TryGetKnownCoordinate(coordinateIdentifier, out coordinateToReturn))
+                            localizer.DebugLog($"Coordinate id: {coordinateIdentifier}, starting discovery.");
+                            if (await coordinateService.TryDiscoverCoordinatesAsync(cancellableCTS.Token, coordinateIdentifier))
                             {
-                                Debug.LogError("We discovered, but for some reason failed to get coordinate from service.");
+                                localizer.DebugLog("Discovery complete, retrieving reference to ISpatialCoordinate");
+                                if (!coordinateService.TryGetKnownCoordinate(coordinateIdentifier, out coordinateToReturn))
+                                {
+                                    Debug.LogError("We discovered, but for some reason failed to get coordinate from service.");
+                                }
                             }
-                        }
-                        else
-                        {
-                            Debug.LogError("Failed to discover spatial coordinate.");
+                            else
+                            {
+                                Debug.LogError("Failed to discover spatial coordinate.");
+                            }
                         }
                     }
                 }
@@ -163,7 +166,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 localizer.Updated -= OnUpdated;
             }
 
-            public void OnDataReceived(BinaryReader reader)
+            public override void OnDataReceived(BinaryReader reader)
             {
                 coordinateIdentifierTaskSource.SetResult(reader.ReadString());
             }

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment.ASA/Scripts/SpectatorView/SpatialAnchorsLocalizer.cs
@@ -168,7 +168,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
             public override void OnDataReceived(BinaryReader reader)
             {
-                coordinateIdentifierTaskSource.SetResult(reader.ReadString());
+                coordinateIdentifierTaskSource.TrySetResult(reader.ReadString());
             }
         }
 #endif

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment/Scripts/Utilities/Extensions.cs
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment/Scripts/Utilities/Extensions.cs
@@ -182,9 +182,9 @@ namespace Microsoft.MixedReality.SpatialAlignment
         /// <param name="task">The task to await.</param>
         /// <param name="cancellationToken">The cancellation token to stop awaiting.</param>
         /// <returns>The task that can be awaited unless the cancellation token is triggered.</returns>
-        public static Task Unless(this Task task, CancellationToken cancellationToken)
+        public static async Task Unless(this Task task, CancellationToken cancellationToken)
         {
-            return Task.WhenAny(task, cancellationToken.AsTask());
+            await (await Task.WhenAny(task, cancellationToken.AsTask()));
         }
 
         /// <summary>
@@ -195,9 +195,16 @@ namespace Microsoft.MixedReality.SpatialAlignment
         /// <param name="task">The task to await.</param>
         /// <param name="cancellationToken">The cancellation token to stop awaiting.</param>
         /// <returns>The task that can be awaited unless the cancellation token is triggered.</returns>
-        public async static Task<T> Unless<T>(this Task<T> task, CancellationToken cancellationToken)
+        public static async Task<T> Unless<T>(this Task<T> task, CancellationToken cancellationToken)
         {
-            return (await Task.WhenAny(task, cancellationToken.AsTask())) is Task<T> result ? result.Result : default(T);
+            Task returnedTask = await Task.WhenAny(task, cancellationToken.AsTask());
+            if (returnedTask is Task<T> taskWithResult)
+            {
+                return await taskWithResult;
+            }
+
+            await returnedTask;
+            return default;
         }
 
         /// <summary>

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/Default Mobile UI.prefab
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/Default Mobile UI.prefab
@@ -1969,7 +1969,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 0, a: 1}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/TCPConnectionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Socketer/TCPConnectionManager.cs
@@ -103,11 +103,20 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             if (client != null)
             {
-                Debug.LogFormat($"Disconnecting existing client {client.Host}:{client.Port}");
-                client.Stop();
-                client.Connected -= OnClientConnected;
-                client.Disconnected -= OnClientDisconnected;
-                client = null;
+                if (client.Host == serverAddress &&
+                    client.Port == port)
+                {
+                    Debug.Log($"Client already created: {client.Host}:{client.Port}");
+                    return;
+                }
+                else
+                {
+                    Debug.Log($"Disconnecting existing client {client.Host}:{client.Port}");
+                    client.Stop();
+                    client.Connected -= OnClientConnected;
+                    client.Disconnected -= OnClientDisconnected;
+                    client = null;
+                }
             }
 
             Debug.LogFormat($"Connecting to {serverAddress}:{port}");

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/ISpatialLocalizationSession.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/ISpatialLocalizationSession.cs
@@ -24,6 +24,11 @@ namespace Microsoft.MixedReality.SpectatorView
         Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken);
 
         /// <summary>
+        /// Call to cancel the localization sessions
+        /// </summary>
+        void Cancel();
+
+        /// <summary>
         /// Call to provide network information
         /// </summary>
         /// <param name="reader">reader containing a network payload</param>

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualDetectorSpatialLocalizer.cs
@@ -79,14 +79,14 @@ namespace Microsoft.MixedReality.SpectatorView
             /// <inheritdoc />
             public override async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
             {
-                if (!defaultCTS.Token.CanBeCanceled)
+                if (!defaultCancellationToken.CanBeCanceled)
                 {
                     Debug.LogError("Session is invalid. No localization performed.");
                     return null;
                 }
 
                 DebugLog($"Waiting for marker visual, CanBeCanceled:{cancellationToken.CanBeCanceled}, IsCancellationRequested:{cancellationToken.IsCancellationRequested}");
-                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCancellationToken, cancellationToken))
                 {
                     await Task.WhenAny(coordinateAssigned.Task, Task.Delay(-1, cancellableCTS.Token));
                     if (string.IsNullOrEmpty(coordinateId))

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualDetectorSpatialLocalizer.cs
@@ -40,9 +40,10 @@ namespace Microsoft.MixedReality.SpectatorView
             return true;
         }
 
-        private class LocalizationSession : DisposableBase, ISpatialLocalizationSession
+        private class LocalizationSession : SpatialLocalizationSession
         {
-            public IPeerConnection Peer => peerConnection;
+            /// <inheritdoc />
+            public override IPeerConnection Peer => peerConnection;
 
             private readonly MarkerVisualDetectorSpatialLocalizer localizer;
             private readonly MarkerVisualDetectorLocalizationSettings settings;
@@ -54,7 +55,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
             private string coordinateId = string.Empty;
 
-            public LocalizationSession(MarkerVisualDetectorSpatialLocalizer localizer, MarkerVisualDetectorLocalizationSettings settings, IPeerConnection peerConnection, bool debugLogging = false)
+            public LocalizationSession(MarkerVisualDetectorSpatialLocalizer localizer, MarkerVisualDetectorLocalizationSettings settings, IPeerConnection peerConnection, bool debugLogging = false) : base()
             {
                 DebugLog("Session created");
                 this.localizer = localizer;
@@ -70,41 +71,51 @@ namespace Microsoft.MixedReality.SpectatorView
             /// <inheritdoc />
             protected override void OnManagedDispose()
             {
-                coordinateService.Dispose();
+                base.OnManagedDispose();
                 discoveryCTS.Dispose();
+                coordinateService.Dispose();
             }
 
             /// <inheritdoc />
-            public async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
+            public override async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
             {
-                DebugLog($"Waiting for marker visual, CanBeCanceled:{cancellationToken.CanBeCanceled}, IsCancellationRequested:{cancellationToken.IsCancellationRequested}");
-                await Task.WhenAny(coordinateAssigned.Task, Task.Delay(-1, cancellationToken));
-                if (string.IsNullOrEmpty(coordinateId))
+                if (!defaultCTS.Token.CanBeCanceled)
                 {
-                    DebugLog("Failed to assign coordinate id");
+                    Debug.LogError("Session is invalid. No localiation performed.");
                     return null;
                 }
 
-                ISpatialCoordinate coordinate = null;
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(discoveryCTS.Token, cancellationToken))
+                DebugLog($"Waiting for marker visual, CanBeCanceled:{cancellationToken.CanBeCanceled}, IsCancellationRequested:{cancellationToken.IsCancellationRequested}");
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
                 {
-                    DebugLog($"Attempting to discover coordinate: {coordinateId}, CanBeCanceled:{cts.Token.CanBeCanceled}, IsCancellationRequested:{cts.Token.IsCancellationRequested}");
-                    if (await coordinateService.TryDiscoverCoordinatesAsync(cts.Token, new string[] { coordinateId.ToString() }))
+                    await Task.WhenAny(coordinateAssigned.Task, Task.Delay(-1, cancellableCTS.Token));
+                    if (string.IsNullOrEmpty(coordinateId))
                     {
-                        DebugLog($"Coordinate discovery completed: {coordinateId}");
-                        if (!coordinateService.TryGetKnownCoordinate(coordinateId, out coordinate))
+                        DebugLog("Failed to assign coordinate id");
+                        return null;
+                    }
+
+                    ISpatialCoordinate coordinate = null;
+                    using (var cts = CancellationTokenSource.CreateLinkedTokenSource(discoveryCTS.Token, cancellableCTS.Token))
+                    {
+                        DebugLog($"Attempting to discover coordinate: {coordinateId}, CanBeCanceled:{cts.Token.CanBeCanceled}, IsCancellationRequested:{cts.Token.IsCancellationRequested}");
+                        if (await coordinateService.TryDiscoverCoordinatesAsync(cts.Token, new string[] { coordinateId.ToString() }))
                         {
-                            DebugLog("Failed to find spatial coordinate although discovery completed.");
+                            DebugLog($"Coordinate discovery completed: {coordinateId}");
+                            if (!coordinateService.TryGetKnownCoordinate(coordinateId, out coordinate))
+                            {
+                                DebugLog("Failed to find spatial coordinate although discovery completed.");
+                            }
+                            else
+                            {
+                                SendCoordinateFound(coordinate.Id);
+                                return coordinate;
+                            }
                         }
                         else
                         {
-                            SendCoordinateFound(coordinate.Id);
-                            return coordinate;
+                            DebugLog("TryDiscoverCoordinatesAsync failed.");
                         }
-                    }
-                    else
-                    {
-                        DebugLog("TryDiscoverCoordinatesAsync failed.");
                     }
                 }
 
@@ -112,7 +123,7 @@ namespace Microsoft.MixedReality.SpectatorView
             }
 
             /// <inheritdoc />
-            public void OnDataReceived(BinaryReader reader)
+            public override void OnDataReceived(BinaryReader reader)
             {
                 string command = reader.ReadString();
                 DebugLog($"Received command: {command}");

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualDetectorSpatialLocalizer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 if (!defaultCTS.Token.CanBeCanceled)
                 {
-                    Debug.LogError("Session is invalid. No localiation performed.");
+                    Debug.LogError("Session is invalid. No localization performed.");
                     return null;
                 }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualSpatialLocalizer.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 DebugLog($"Localizing, CanBeCanceled:{cancellationToken.CanBeCanceled}, IsCancellationRequested:{cancellationToken.IsCancellationRequested}");
 
                 ISpatialCoordinate coordinate = null;
-                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCancellationToken, cancellationToken))
                 {
                     if (!TrySendMarkerVisualDiscoveryMessage())
                     {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/MarkerVisualSpatialLocalizer.cs
@@ -77,9 +77,10 @@ namespace Microsoft.MixedReality.SpectatorView
             return true;
         }
 
-        private class LocalizationSession : DisposableBase, ISpatialLocalizationSession
+        private class LocalizationSession : SpatialLocalizationSession
         {
-            public IPeerConnection Peer => peerConnection;
+            /// <inheritdoc />
+            public override IPeerConnection Peer => peerConnection;
 
             private readonly MarkerVisualSpatialLocalizer localizer;
             private readonly MarkerVisualLocalizationSettings settings;
@@ -92,7 +93,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
             private string coordinateId = string.Empty;
 
-            public LocalizationSession(MarkerVisualSpatialLocalizer localizer, MarkerVisualLocalizationSettings settings, IPeerConnection peerConnection, bool debugLogging = false)
+            public LocalizationSession(MarkerVisualSpatialLocalizer localizer, MarkerVisualLocalizationSettings settings, IPeerConnection peerConnection, bool debugLogging = false) : base()
             {
                 DebugLog("Session created");
                 this.localizer = localizer;
@@ -111,55 +112,60 @@ namespace Microsoft.MixedReality.SpectatorView
             /// <inheritdoc />
             protected override void OnManagedDispose()
             {
-                coordinateService.Dispose();
+                base.OnManagedDispose();
                 discoveryCTS.Dispose();
+                coordinateService.Dispose();
             }
 
             /// <inheritdoc />
-            public async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
+            public override async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
             {
                 DebugLog($"Localizing, CanBeCanceled:{cancellationToken.CanBeCanceled}, IsCancellationRequested:{cancellationToken.IsCancellationRequested}");
-                if (!TrySendMarkerVisualDiscoveryMessage())
-                {
-                    Debug.LogWarning("Failed to send marker visual discovery message, spatial localization failed.");
-                    return null;
-                }
-
-                // Receive marker to show
-                DebugLog("Waiting to have a coordinate id assigned");
-                await Task.WhenAny(coordinateAssigned.Task, Task.Delay(-1, cancellationToken));
-                if (string.IsNullOrEmpty(coordinateId))
-                {
-                    DebugLog("Failed to assign coordinate id");
-                    return null;
-                }
 
                 ISpatialCoordinate coordinate = null;
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(discoveryCTS.Token, cancellationToken))
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
                 {
-                    DebugLog($"Attempting to discover coordinate: {coordinateId}, CanBeCanceled:{cts.Token.CanBeCanceled}, IsCancellationRequested:{cts.Token.IsCancellationRequested}");
-                    if (await coordinateService.TryDiscoverCoordinatesAsync(cts.Token, new string[] { coordinateId.ToString() }))
+                    if (!TrySendMarkerVisualDiscoveryMessage())
                     {
-                        DebugLog($"Coordinate discovery completed: {coordinateId}");
-                        if (!coordinateService.TryGetKnownCoordinate(coordinateId, out coordinate))
+                        Debug.LogWarning("Failed to send marker visual discovery message, spatial localization failed.");
+                        return null;
+                    }
+
+                    // Receive marker to show
+                    DebugLog("Waiting to have a coordinate id assigned");
+                    await Task.WhenAny(coordinateAssigned.Task, Task.Delay(-1, cancellableCTS.Token));
+                    if (string.IsNullOrEmpty(coordinateId))
+                    {
+                        DebugLog("Failed to assign coordinate id");
+                        return null;
+                    }
+
+                    using (var cts = CancellationTokenSource.CreateLinkedTokenSource(discoveryCTS.Token, cancellableCTS.Token))
+                    {
+                        DebugLog($"Attempting to discover coordinate: {coordinateId}, CanBeCanceled:{cts.Token.CanBeCanceled}, IsCancellationRequested:{cts.Token.IsCancellationRequested}");
+                        if (await coordinateService.TryDiscoverCoordinatesAsync(cts.Token, new string[] { coordinateId.ToString() }))
                         {
-                            DebugLog("Failed to find spatial coordinate although discovery completed.");
+                            DebugLog($"Coordinate discovery completed: {coordinateId}");
+                            if (!coordinateService.TryGetKnownCoordinate(coordinateId, out coordinate))
+                            {
+                                DebugLog("Failed to find spatial coordinate although discovery completed.");
+                            }
+                        }
+                        else
+                        {
+                            DebugLog("TryDiscoverCoordinatesAsync failed.");
                         }
                     }
-                    else
-                    {
-                        DebugLog("TryDiscoverCoordinatesAsync failed.");
-                    }
-                }
 
-                DebugLog($"Waiting for coordinate to be found: {coordinateId}");
-                await Task.WhenAny(coordinateFound.Task, Task.Delay(-1, cancellationToken));
+                    DebugLog($"Waiting for coordinate to be found: {coordinateId}");
+                    await Task.WhenAny(coordinateFound.Task, Task.Delay(-1, cancellableCTS.Token));
+                }
 
                 return coordinate;
             }
 
             /// <inheritdoc />
-            public void OnDataReceived(BinaryReader reader)
+            public override void OnDataReceived(BinaryReader reader)
             {
                 string command = reader.ReadString();
                 DebugLog($"Received command: {command}");

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/MarkerDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/MarkerDetectorSpatialLocalizer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 localizer.DebugLog("Getting host coordinate");
 
                 ISpatialCoordinate spatialCoordinate = null;
-                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCancellationToken, cancellationToken))
                 {
                     await coordinateService.TryDiscoverCoordinatesAsync(cancellationToken, new int[] { settings.MarkerID });
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/MarkerDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/MarkerDetectorSpatialLocalizer.cs
@@ -67,11 +67,6 @@ namespace Microsoft.MixedReality.SpectatorView
             }
 
             /// <inheritdoc />
-            public override void OnDataReceived(BinaryReader reader)
-            {
-            }
-
-            /// <inheritdoc />
             protected override void OnManagedDispose()
             {
                 base.OnManagedDispose();

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
@@ -386,7 +386,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private async Task<bool> RunLocalizationSessionAsync(ISpatialLocalizer localizer, ISpatialLocalizationSettings settings, SpatialCoordinateSystemParticipant participant)
         {
-            // TODO - this isn't thread safe
+            // TODO - this functionality should be revamped for thread safety.
             if (currentLocalizationSession != null)
             {
                 if (participant == currentLocalizationSession.Peer)

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
@@ -205,7 +205,7 @@ namespace Microsoft.MixedReality.SpectatorView
             if (remoteLocalizationSessions.TryGetValue(socketEndpoint, out var currentCompletionSource))
             {
                 DebugLog("Canceling existing remote localization session: {socketEndpoint.Address}");
-                currentCompletionSource.TrySetResult(false);
+                currentCompletionSource.TrySetCanceled();
                 remoteLocalizationSessions.Remove(socketEndpoint);
             }
 
@@ -472,6 +472,10 @@ namespace Microsoft.MixedReality.SpectatorView
                                 Debug.LogWarning("Localization session completed but was no longer assigned to the associated participant");
                             }
                         }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        DebugLog("Localization operation cancelled.");
                     }
                     catch (Exception e)
                     {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private HashSet<INetworkManager> networkManagers = new HashSet<INetworkManager>();
         private ITrackingObserver trackingObserver = null;
 
-        private object localizationLock = new object();
+        private readonly object localizationLock = new object();
         private LocalizationSessionDetails currentLocalizationSession = null;
 
         private class LocalizationSessionDetails

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemManager.cs
@@ -302,11 +302,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private void OnDisconnected(SocketEndpoint endpoint)
         {
-            if (participants.TryGetValue(endpoint, out var participant) &&
-                participant.SocketEndpoint == endpoint)
+            if (participants.TryGetValue(endpoint, out var participant))
             {
-                // If multiple connections are attempted changing endpoints, multiple disconnects should exist.
-                // We should only tear down this functionality when the disconnect comes from the used endpoint compared to the IPAddress.
                 TryCleanupExistingLocalizationSession(participant);
                 participant.Dispose();
                 participants.Remove(endpoint);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemParticipant.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemParticipant.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private bool showDebugVisuals;
         private readonly TaskCompletionSource<ISet<Guid>> peerSupportedLocalizersTaskSource = new TaskCompletionSource<ISet<Guid>>();
 
-        public SocketEndpoint SocketEndpoint { get; }
+        public SocketEndpoint SocketEndpoint { get; set; }
 
         public SpatialCoordinateSystemParticipant(SocketEndpoint endpoint, GameObject debugVisualPrefab, float debugVisualScale)
         {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemParticipant.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateSystemParticipant.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private bool showDebugVisuals;
         private readonly TaskCompletionSource<ISet<Guid>> peerSupportedLocalizersTaskSource = new TaskCompletionSource<ISet<Guid>>();
 
-        public SocketEndpoint SocketEndpoint { get; set; }
+        public SocketEndpoint SocketEndpoint { get; }
 
         public SpatialCoordinateSystemParticipant(SocketEndpoint endpoint, GameObject debugVisualPrefab, float debugVisualScale)
         {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateTransformer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialCoordinateTransformer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.SpectatorView
             DebugLog($"Participant disconnected: {participant?.SocketEndpoint?.Address ?? "IPAddress unknown"}");
             if (currentParticipant == null)
             {
-                Debug.LogError("Unexpected that no participant was registered when a participant disconnected");
+                DebugLog("No participant was registered when a participant disconnected");
             }
             currentParticipant = null;
         }
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.SpectatorView
             DebugLog($"Participant connected: {participant?.SocketEndpoint?.Address ?? "IPAddress unknown"}");
             if (currentParticipant != null)
             {
-                Debug.LogError("Unexpected existing participant when another participant connected");
+                DebugLog("Participant was already registered when new participant connected");
             }
             currentParticipant = participant;
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
@@ -33,7 +33,9 @@ namespace Microsoft.MixedReality.SpectatorView
         /// <inheritdoc />
         public void Cancel()
         {
-            if (defaultCTS.Token.CanBeCanceled)
+            if (!this.IsDisposed &&
+                defaultCTS != null &&
+                defaultCTS.Token.CanBeCanceled)
             {
                 defaultCTS.Cancel();
             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
@@ -10,7 +10,8 @@ namespace Microsoft.MixedReality.SpectatorView
 {
     public abstract class SpatialLocalizationSession : DisposableBase, ISpatialLocalizationSession
     {
-        protected readonly CancellationTokenSource defaultCTS = null;
+        private readonly CancellationTokenSource defaultCTS = null;
+        protected readonly CancellationToken defaultCancellationToken;
 
         /// <inheritdoc />
         public abstract IPeerConnection Peer { get; }
@@ -18,7 +19,8 @@ namespace Microsoft.MixedReality.SpectatorView
         /// <inheritdoc />
         public SpatialLocalizationSession()
         {
-            this.defaultCTS = new CancellationTokenSource();
+            defaultCTS = new CancellationTokenSource();
+            defaultCancellationToken = defaultCTS.Token;
         }
 
         /// <inheritdoc />

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.SpatialAlignment;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.MixedReality.SpectatorView
+{
+    public abstract class SpatialLocalizationSession : DisposableBase, ISpatialLocalizationSession
+    {
+        protected readonly CancellationTokenSource defaultCTS = null;
+
+        /// <inheritdoc />
+        public abstract IPeerConnection Peer { get; }
+
+        /// <inheritdoc />
+        public SpatialLocalizationSession()
+        {
+            this.defaultCTS = new CancellationTokenSource();
+        }
+
+        /// <inheritdoc />
+        protected override void OnManagedDispose()
+        {
+            defaultCTS.Dispose();
+        }
+
+        /// <inheritdoc />
+        public abstract Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken);
+
+        /// <inheritdoc />
+        public void Cancel()
+        {
+            if (defaultCTS.Token.CanBeCanceled)
+            {
+                defaultCTS.Cancel();
+            }
+        }
+
+        /// <inheritdoc />
+        public abstract void OnDataReceived(BinaryReader reader);
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs
@@ -44,6 +44,6 @@ namespace Microsoft.MixedReality.SpectatorView
         }
 
         /// <inheritdoc />
-        public abstract void OnDataReceived(BinaryReader reader);
+        public virtual void OnDataReceived(BinaryReader reader) { }
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/SpatialLocalizationSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 327f651904cbf9e4fbe2ceb4a8abe4f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
@@ -116,11 +116,6 @@ namespace Microsoft.MixedReality.SpectatorView
 
                 return await Task.FromResult(spatialCoordinate);
             }
-
-            /// <inheritdoc />
-            public override void OnDataReceived(BinaryReader reader)
-            {
-            }
         }
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 if (!defaultCTS.Token.CanBeCanceled)
                 {
-                    Debug.LogError("Session is invalid. No localiation performed.");
+                    Debug.LogError("Session is invalid. No localization performed.");
                     return null;
                 }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
@@ -82,14 +82,14 @@ namespace Microsoft.MixedReality.SpectatorView
             /// <inheritdoc />
             public override async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
             {
-                if (!defaultCTS.Token.CanBeCanceled)
+                if (!defaultCancellationToken.CanBeCanceled)
                 {
                     Debug.LogError("Session is invalid. No localization performed.");
                     return null;
                 }
 
                 ISpatialCoordinate spatialCoordinate = null;
-                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCancellationToken, cancellationToken))
                 {
                     WorldAnchorCoordinateService coordinateService = await localizer.coordinateServiceTask.Unless(cancellationToken);
                     if (cancellationToken.IsCancellationRequested)

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorSpatialLocalizer.cs
@@ -63,47 +63,62 @@ namespace Microsoft.MixedReality.SpectatorView
             return true;
         }
 
-        private class LocalizationSession : DisposableBase, ISpatialLocalizationSession
+        private class LocalizationSession : SpatialLocalizationSession
         {
-            public IPeerConnection Peer => peerConnection;
+            /// <inheritdoc />
+            public override IPeerConnection Peer => peerConnection;
 
             private readonly WorldAnchorSpatialLocalizer localizer;
             private readonly WorldAnchorSpatialLocalizationSettings settings;
             private readonly IPeerConnection peerConnection;
 
-            public LocalizationSession(WorldAnchorSpatialLocalizer localizer, WorldAnchorSpatialLocalizationSettings settings, IPeerConnection peerConnection)
+            public LocalizationSession(WorldAnchorSpatialLocalizer localizer, WorldAnchorSpatialLocalizationSettings settings, IPeerConnection peerConnection) : base()
             {
                 this.localizer = localizer;
                 this.settings = settings;
                 this.peerConnection = peerConnection;
             }
 
-            public async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
+            /// <inheritdoc />
+            public override async Task<ISpatialCoordinate> LocalizeAsync(CancellationToken cancellationToken)
             {
-                WorldAnchorCoordinateService coordinateService = await localizer.coordinateServiceTask.Unless(cancellationToken);
-                if (cancellationToken.IsCancellationRequested)
+                if (!defaultCTS.Token.CanBeCanceled)
                 {
+                    Debug.LogError("Session is invalid. No localiation performed.");
                     return null;
                 }
 
-                if (settings.Mode == WorldAnchorLocalizationMode.LocateExistingAnchor)
+                ISpatialCoordinate spatialCoordinate = null;
+                using (var cancellableCTS = CancellationTokenSource.CreateLinkedTokenSource(defaultCTS.Token, cancellationToken))
                 {
-                    if (coordinateService.TryGetKnownCoordinate(settings.AnchorId, out ISpatialCoordinate coordinate))
-                    {
-                        return coordinate;
-                    }
-                    else
+                    WorldAnchorCoordinateService coordinateService = await localizer.coordinateServiceTask.Unless(cancellationToken);
+                    if (cancellationToken.IsCancellationRequested)
                     {
                         return null;
                     }
+
+                    if (settings.Mode == WorldAnchorLocalizationMode.LocateExistingAnchor)
+                    {
+                        if (coordinateService.TryGetKnownCoordinate(settings.AnchorId, out ISpatialCoordinate coordinate))
+                        {
+                            return coordinate;
+                        }
+                        else
+                        {
+                            return null;
+                        }
+                    }
+                    else
+                    {
+                        spatialCoordinate = await coordinateService.CreateCoordinateAsync(settings.AnchorId, settings.AnchorPosition, settings.AnchorRotation, cancellationToken);
+                    }
                 }
-                else
-                {
-                    return await coordinateService.CreateCoordinateAsync(settings.AnchorId, settings.AnchorPosition, settings.AnchorRotation, cancellationToken);
-                }
+
+                return await Task.FromResult(spatialCoordinate);
             }
 
-            public void OnDataReceived(BinaryReader reader)
+            /// <inheritdoc />
+            public override void OnDataReceived(BinaryReader reader)
             {
             }
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
@@ -389,6 +389,8 @@ namespace Microsoft.MixedReality.SpectatorView
         private void OnNetworkConfigurationUpdated(object sender, string ipAddress)
         {
 #if UNITY_ANDROID || UNITY_IOS
+            DebugLog($"OnNetworkConfigurationUpdated: ipAddress:{ipAddress}");
+
             this.userIpAddress = ipAddress;
             if (networkConfigurationVisual != null)
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpectatorView.cs
@@ -470,22 +470,28 @@ namespace Microsoft.MixedReality.SpectatorView
                 supportedLocalizers != null)
             {
                 DebugLog($"Received a set of {peerSupportedLocalizers.Count} supported localizers");
-                DebugLog($"Using prioritized initializers list from spectator view settings: {SpatialLocalizationInitializationSettings.IsInitialized && SpatialLocalizationInitializationSettings.Instance.PrioritizedInitializers != null}");
 
+                var initializers = new List<SpatialLocalizationInitializer>();
                 if (SpatialLocalizationInitializationSettings.IsInitialized &&
-                    await TryRunLocalizationWithInitializerAsync(SpatialLocalizationInitializationSettings.Instance.PrioritizedInitializers, supportedLocalizers, participant))
+                    SpatialLocalizationInitializationSettings.Instance.PrioritizedInitializers != null)
                 {
-                    // Succeeded at using a custom localizer specified by the app.
-                    return true;
+                    DebugLog($"Found prioritized spatial localization initializers list in spectator view settings");
+                    foreach(var initializer in SpatialLocalizationInitializationSettings.Instance.PrioritizedInitializers)
+                    {
+                        initializers.Add(initializer);
+                    }
                 }
 
-                if (await TryRunLocalizationWithInitializerAsync(defaultSpatialLocalizationInitializers, supportedLocalizers, participant))
+                if (defaultSpatialLocalizationInitializers != null)
                 {
-                    // Succeeded at using one of the default localizers from the prefab.
-                    return true;
+                    DebugLog($"Found default spatial localization initializers list for spectator view settings");
+                    foreach (var initializer in defaultSpatialLocalizationInitializers)
+                    {
+                        initializers.Add(initializer);
+                    }
                 }
 
-                Debug.LogWarning($"None of the configured LocalizationInitializers were supported by the connected participant, localization will not be started");
+                return await TryRunLocalizationWithInitializerAsync(initializers, supportedLocalizers, participant);
             }
             else
             {
@@ -497,12 +503,12 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private async Task<bool> TryRunLocalizationWithInitializerAsync(IList<SpatialLocalizationInitializer> initializers, ISet<Guid> supportedLocalizers, SpatialCoordinateSystemParticipant participant)
         {
-            DebugLog($"TryRunLocalizationWithInitializerAsync");
-
-            if (initializers == null)
+            if (initializers == null || supportedLocalizers == null)
             {
+                Debug.LogWarning("Did not find a supported localizer/initializer combination.");
                 return false;
             }
+            DebugLog($"TryRunLocalizationWithInitializerAsync, initializers:{initializers.Count}, supportedLocalizers:{supportedLocalizers.Count}");
 
             for (int i = 0; i < initializers.Count; i++)
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/UI/SpatialAlignmentVisual.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/UI/SpatialAlignmentVisual.cs
@@ -15,6 +15,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private SpectatorView spectatorView;
         private readonly string spatialAlignmentStatePrompt = "Experience spatially aligned:";
+        private readonly string spatialAlignmentRunningPrompt = "Running spatial alignment...";
 
         private void Start()
         {
@@ -31,10 +32,16 @@ namespace Microsoft.MixedReality.SpectatorView
                     spatialAlignmentStateText.text = $"{spatialAlignmentStatePrompt} True";
                     spatialAlignmentStateText.color = Color.green;
                 }
+                else if (SpatialCoordinateSystemManager.IsInitialized &&
+                    SpatialCoordinateSystemManager.Instance.LocalizationRunning)
+                {
+                    spatialAlignmentStateText.text = spatialAlignmentRunningPrompt;
+                    spatialAlignmentStateText.color = Color.yellow;
+                }
                 else
                 {
                     spatialAlignmentStateText.text = $"{spatialAlignmentStatePrompt} False";
-                    spatialAlignmentStateText.color = Color.yellow;
+                    spatialAlignmentStateText.color = Color.red;
                 }
             }
         }
@@ -47,7 +54,7 @@ namespace Microsoft.MixedReality.SpectatorView
             }
             else
             {
-                Debug.LogError("SpectatorView was not found in the scene, failed to reset localiation.");
+                Debug.LogError("SpectatorView was not found in the scene, failed to reset localization.");
             }
         }
     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/Dispatcher.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/Dispatcher.cs
@@ -1,0 +1,218 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.MixedReality.SpectatorView
+{
+    /// <summary>
+    /// A helper class to Dispatch actions to the GameThread
+    /// </summary>
+    public static class Dispatcher
+    {
+        private static int? mainThreadId = null;
+        private static TaskScheduler mainThreadScheduler;
+
+        public static void Initialize(int mainThreadId, TaskScheduler mainThreadScheduler)
+        {
+            if (Dispatcher.mainThreadId.HasValue)
+            {
+                throw new InvalidOperationException("Dispatcher already initialized.");
+            }
+
+            Dispatcher.mainThreadId = mainThreadId;
+            Dispatcher.mainThreadScheduler = mainThreadScheduler;
+        }
+
+        public static void Unintialize()
+        {
+            mainThreadId = null;
+            mainThreadScheduler = null;
+        }
+
+        /// <summary>
+        /// Returns the Id of the current managed thread.
+        /// </summary>
+        public static int CurrentThreadId
+        {
+            get
+            {
+#if WINDOWS_UWP
+                return Environment.CurrentManagedThreadId;
+#else
+                return Thread.CurrentThread.ManagedThreadId;
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Returns whether or not the calling thread is in fact a game thread.
+        /// </summary>
+        public static bool IsGameThread { get { return CurrentThreadId == mainThreadId; } }
+
+        /// <summary>
+        /// A helper that throws if the current thread is not a game thread.
+        /// </summary>
+        public static void ThrowIfNotGameThread()
+        {
+            if (mainThreadId == null)
+            {
+                throw new InvalidOperationException("Dispatcher not initialized.");
+            }
+
+            if (!IsGameThread)
+            {
+                throw new InvalidOperationException("The current thread is not the game thread.");
+            }
+        }
+
+        /// <summary>
+        /// Schedules an action to be executed on the GameThread task scheduler.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the operation.</param>
+        /// <param name="runImmediateIfOnGameThread">If true, will check if current thread is the game thread and execute the dispatched operation immediately.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        public static Task ScheduleAsync(Action action, CancellationToken cancellationToken, bool runImmediateIfOnGameThread = false)
+        {
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (runImmediateIfOnGameThread && IsGameThread)
+            {
+                try
+                {
+                    action();
+                    return Task.CompletedTask;
+                }
+                // Ensure same behaviour for exception handling on consuming side.
+                catch (Exception ex)
+                {
+                    return Task.FromException(ex);
+                }
+            }
+            else
+            {
+                Task task = new Task(action, cancellationToken);
+                task.Start(mainThreadScheduler);
+                return task;
+            }
+        }
+
+        /// <summary>
+        /// Schedules a function to be executed on the GameThread task scheduler.
+        /// </summary>
+        /// <typeparam name="TResult">The generic type of the return parameter.</typeparam>
+        /// <param name="func">The function to execute.</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the operation.</param>
+        /// <param name="runImmediateIfOnGameThread">If true, will check if current thread is the game thread and execute the dispatched operation immediately.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        public static Task<TResult> ScheduleAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, bool runImmediateIfOnGameThread = false)
+        {
+            if (func == null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
+            if (runImmediateIfOnGameThread && IsGameThread)
+            {
+                try
+                {
+                    return Task.FromResult(func());
+                }
+                // Ensure same behaviour for exception handling on consuming side.
+                catch (Exception ex)
+                {
+                    return Task.FromException<TResult>(ex);
+                }
+            }
+            else
+            {
+                Task<TResult> task = new Task<TResult>(func, cancellationToken);
+                task.Start(mainThreadScheduler);
+                return task;
+            }
+        }
+
+        /// <summary>
+        /// Schedules an asyncrhonous action to be executed on the GameThread task scheduler.
+        /// </summary>
+        /// <param name="asyncAction">The asyncrhonous action to execute.</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the operation.</param>
+        /// <param name="runImmediateIfOnGameThread">If true, will check if current thread is the game thread and execute the dispatched operation immediately.</param>
+        /// <returns>The Task representing the unwrapped asynchronous operation.</returns>
+        public static Task ScheduleAsync(Func<Task> asyncAction, CancellationToken cancellationToken, bool runImmediateIfOnGameThread = false)
+        {
+            return ScheduleAsync<Task>(asyncAction, cancellationToken, runImmediateIfOnGameThread).Unwrap();
+        }
+
+        /// <summary>
+        /// Schedules an asycnrhonous function to be executed on the GameThread task scheduler.
+        /// </summary>
+        /// <typeparam name="TResult">The generic type of the return parameter.</typeparam>
+        /// <param name="func">The asynchronous function to execute.</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the operation.</param>
+        /// <param name="runImmediateIfOnGameThread">If true, will check if current thread is the game thread and execute the dispatched operation immediately.</param>
+        /// <returns>The Task representing the unwrapped asynchronous operation.</returns>
+        public static Task<TResult> ScheduleAsync<TResult>(Func<Task<TResult>> asyncFunc, CancellationToken cancellationToken, bool runImmediateIfOnGameThread = false)
+        {
+            return ScheduleAsync<Task<TResult>>(asyncFunc, cancellationToken, runImmediateIfOnGameThread).Unwrap();
+        }
+
+        /// <summary>
+        /// A helper to wait for next frame.
+        /// </summary>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        public static async Task WaitForNextFrameAsync()
+        {
+            ThrowIfNotGameThread();
+
+            await Task.Delay(1);
+        }
+
+        /// <summary>
+        /// Conducts a polling wait on the game thread until a predicate is satisfied.
+        /// </summary>
+        /// <param name="predicate">The condition to wait for.</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the operation.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        public static Task WhenAsync(Func<bool> predicate, CancellationToken cancellationToken)
+        {
+            return ScheduleAsync(async () =>
+            {
+                while (!predicate())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await WaitForNextFrameAsync();
+                }
+            }, cancellationToken);
+        }
+
+        /// <summary>
+        /// Conducts a polling wait on the game thread until an result returend by an evaluator is no longer null.
+        /// </summary>
+        /// <param name="evaluator">The function that returns the result to check for null.</param>
+        /// <param name="cancellationToken">CancellationToken to cancel the operation.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        public static Task<T> WhenNotNullAsync<T>(Func<T> evaluator, CancellationToken cancellationToken) where T : class
+        {
+            return ScheduleAsync(async () =>
+            {
+                T item;
+                while ((item = evaluator()) == null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await WaitForNextFrameAsync();
+                }
+
+                return item;
+            }, cancellationToken);
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/Dispatcher.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/Dispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b431c88f5bf4b2947b5d4d555934f845
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/DispatcherUnity.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/DispatcherUnity.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.SpectatorView
+{
+    /// <summary>
+    /// A helper class to Dispatch actions to the GameThread
+    /// </summary>
+    public static class DispatcherUnity
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Init()
+        {
+            Dispatcher.Initialize(Dispatcher.CurrentThreadId, TaskScheduler.FromCurrentSynchronizationContext());
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/DispatcherUnity.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Utilities/DispatcherUnity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d9c0b14943c3ee4e921033e874c07c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This review addresses: https://github.com/microsoft/MixedReality-SpectatorView/issues/242

In this review:
1) ILocalizationSession is extended to have a Cancel function defined. This is beneficial because it eases cleanup when a network connection is lost.
2) SpatialLocalizationSession was created as a base class. This base class contains cancellation token sources for tearing down localization on cancel.
3) Dispatcher and DispatcherUnity were created to ease scheduling tasks on the ui thread.
4) We now lock when accessing the current localization session in SpatialCoordinateSystemManager.
5) SpatialCoordinateSystemManager now has a flag that states whether localization is running.
6) SpatialAlignmentVisual now displays to the user when localization is running.

## Breaking Change Details:
### Notes:
This review introduces breaking changes to ISpatialLocalizationSession. Contributors felt there was a need to be able to cancel sessions, which led to this change.

### Migration Instructions:
1) Update custom implementations of ISpatialLocalizationSession to support a Cancel function.