### PR TITLE
Fix the powershell to get all symbolic links and restore them

### DIFF
--- a/tools/Scripts/SymbolicLinkHelpers.psm1
+++ b/tools/Scripts/SymbolicLinkHelpers.psm1
@@ -51,7 +51,7 @@ Function FixSymbolicLinks {
 	# If any links were created to the submodules but were broken,
 	# restore those symlinks now that the submodules are cloned.
 	Write-Output "Fixing all symbolic links."
-	dir Get-Location -Recurse -File | ?{$_.LinkType -eq "SymbolicLink" } | Restore-SymbolicLink
+	"$(Get-Location)\..\..\" | dir -Recurse -File | ?{$_.LinkType -eq "SymbolicLink" } | Restore-SymbolicLink
 
 	# If any links were created before the repository was configured to use
 	# symlinks, those links need to be restored.


### PR DESCRIPTION
This change corrects the pipe for getting the write directory to recurse for symbolic links.