### PR TITLE
Add deterministic asset id generation process for asset caches.

### DIFF
--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/AudioClipAssetCache.asset
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/AudioClipAssetCache.asset
@@ -14,77 +14,132 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: b123fb06-5b65-4d62-98f9-92b4de42f265
-    Asset: {fileID: 8300000, guid: 3448d870fb0a1b24ab44f20f2e1f982d, type: 3}
-  - AssetId:
-      m_storage: 99f3d57f-1ae0-43e3-bd82-9d547d7799dc
-    Asset: {fileID: 8300000, guid: 7c430ff14341f8a40b9f26b20cbcf2dc, type: 3}
-  - AssetId:
-      m_storage: 6620a750-4689-4bcf-918e-a55c467b8f22
-    Asset: {fileID: 8300000, guid: 45a90682f74bb0c41b65994c63b74e60, type: 3}
-  - AssetId:
-      m_storage: 9e26d114-b6ff-47e6-a1b2-7261727d0d16
-    Asset: {fileID: 8300000, guid: 72d90092d0f1a734eb1cfcf71b8fa2e4, type: 3}
-  - AssetId:
-      m_storage: fcdecf8d-f1db-44e3-8a7d-0dadfec9772a
-    Asset: {fileID: 8300000, guid: 23a78d131feb8774ebe5dd1ea221933e, type: 3}
-  - AssetId:
-      m_storage: 55af1c46-52a4-49e4-b8a9-7a6f7250b84d
-    Asset: {fileID: 8300000, guid: 848c1453f7177fb46a18dff735a5fdc4, type: 3}
-  - AssetId:
-      m_storage: 4175495a-03ba-4bf4-929e-97f24e403d46
-    Asset: {fileID: 8300000, guid: 32c013149113ba24cb267e1e3f6725c7, type: 3}
-  - AssetId:
-      m_storage: ee5e432f-8282-4371-9b7f-c74ff0ae17c6
-    Asset: {fileID: 8300000, guid: ee0cdf449e9bc854f919aa6826ce6ab8, type: 3}
-  - AssetId:
-      m_storage: 45b0fdd0-ae36-48d9-ae60-9ab62284bb9c
-    Asset: {fileID: 8300000, guid: 2193e9060a088b24f97f48d1e1a4a862, type: 3}
-  - AssetId:
-      m_storage: 8ca2196a-690f-42a9-848a-5b80c6280a7e
-    Asset: {fileID: 8300000, guid: 34c7d0366474b494a8d3bedb6f797008, type: 3}
-  - AssetId:
-      m_storage: 3ab301f7-2644-4487-8afc-3f92191c1fa1
-    Asset: {fileID: 8300000, guid: ec33d8a6027c1574390812966f8aef94, type: 3}
-  - AssetId:
-      m_storage: 9d8810b6-7704-4082-943e-ceab300d5420
-    Asset: {fileID: 8300000, guid: 170429180f309a940b54c1001e94e54c, type: 3}
-  - AssetId:
-      m_storage: b186a45b-d793-41b8-bc3d-17c8f93b7774
-    Asset: {fileID: 8300000, guid: 06f9d598e90313646bbff63530142344, type: 3}
-  - AssetId:
-      m_storage: c2392508-1a12-48df-919d-9b0e5b1f2ed7
-    Asset: {fileID: 8300000, guid: 8ae8d019d0540b44e80d623f6ca47d64, type: 3}
-  - AssetId:
-      m_storage: 1ffae3e8-1ae9-4a71-8467-4e35f4944985
-    Asset: {fileID: 8300000, guid: 6c0efce9e4f4243449555af66e975f27, type: 3}
-  - AssetId:
-      m_storage: d806065b-9d88-4057-8ebf-1ce654fb25ca
-    Asset: {fileID: 8300000, guid: bdc1f15a0c976854780adcd7e56cfb3e, type: 3}
-  - AssetId:
-      m_storage: 5e936425-4890-45ec-9d33-aa46a95ab0fd
+      guid:
+        m_storage: 0632575a-55cf-0934-9a99-9a10968f6395
+      fileIdentifier: 8300000
     Asset: {fileID: 8300000, guid: 0632575a55cf09349a999a10968f6395, type: 3}
   - AssetId:
-      m_storage: 2dab5ec8-41ba-4ae5-8a7a-3ab541d9cc94
-    Asset: {fileID: 8300000, guid: 9d90886bb6646244e852a0acb1de3a3b, type: 3}
+      guid:
+        m_storage: 06f9d598-e903-1364-6bbf-f63530142344
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 06f9d598e90313646bbff63530142344, type: 3}
   - AssetId:
-      m_storage: 87016a9b-0d93-4eeb-8e45-f9dd342258e7
-    Asset: {fileID: 8300000, guid: e35ddb0c8710c2949a37a6975f6847db, type: 3}
+      guid:
+        m_storage: 17042918-0f30-9a94-0b54-c1001e94e54c
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 170429180f309a940b54c1001e94e54c, type: 3}
   - AssetId:
-      m_storage: 91d132b1-dd19-4714-a706-b6d06dfdd597
-    Asset: {fileID: 8300000, guid: ac992f1ec8cfba145b10655b334ec711, type: 3}
+      guid:
+        m_storage: 2193e906-0a08-8b24-f97f-48d1e1a4a862
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 2193e9060a088b24f97f48d1e1a4a862, type: 3}
   - AssetId:
-      m_storage: 588806e8-b3be-4cf4-8206-ea3d08cf6114
+      guid:
+        m_storage: 23a78d13-1feb-8774-ebe5-dd1ea221933e
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 23a78d131feb8774ebe5dd1ea221933e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2671478f-e011-5a94-e8f2-fdc0799fac23
+      fileIdentifier: 8300000
     Asset: {fileID: 8300000, guid: 2671478fe0115a94e8f2fdc0799fac23, type: 3}
   - AssetId:
-      m_storage: 0c6dc156-3914-40e1-8ce9-092590369f93
-    Asset: {fileID: 8300000, guid: 5e03cdafc88015c47af4cad5d65de327, type: 3}
+      guid:
+        m_storage: 269b9f0f-a8c9-30b4-ea7a-e2bf7b250820
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 269b9f0fa8c930b4ea7ae2bf7b250820, type: 3}
   - AssetId:
-      m_storage: 133d155f-3c46-424b-9694-a50aa02c2f7e
-    Asset: {fileID: 8300000, guid: 765efbcf7ca1773488edcc8ab6ba4923, type: 3}
-  - AssetId:
-      m_storage: cf128860-ce21-425d-b863-148329263ab0
+      guid:
+        m_storage: 291bf932-6e51-7b04-89c2-ee53d0a6a63f
+      fileIdentifier: 8300000
     Asset: {fileID: 8300000, guid: 291bf9326e517b0489c2ee53d0a6a63f, type: 3}
   - AssetId:
-      m_storage: 2339aa42-0ff5-4540-9fcb-a09ebe0a6743
+      guid:
+        m_storage: 32c01314-9113-ba24-cb26-7e1e3f6725c7
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 32c013149113ba24cb267e1e3f6725c7, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3448d870-fb0a-1b24-ab44-f20f2e1f982d
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 3448d870fb0a1b24ab44f20f2e1f982d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 34c7d036-6474-b494-a8d3-bedb6f797008
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 34c7d0366474b494a8d3bedb6f797008, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 40ae713d-df42-0714-bbc1-a3b5c3f2eac1
+      fileIdentifier: 8300000
     Asset: {fileID: 8300000, guid: 40ae713ddf420714bbc1a3b5c3f2eac1, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 45a90682-f74b-b0c4-1b65-994c63b74e60
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 45a90682f74bb0c41b65994c63b74e60, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 5e03cdaf-c880-15c4-7af4-cad5d65de327
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 5e03cdafc88015c47af4cad5d65de327, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6c0efce9-e4f4-2434-4955-5af66e975f27
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 6c0efce9e4f4243449555af66e975f27, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 72d90092-d0f1-a734-eb1c-fcf71b8fa2e4
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 72d90092d0f1a734eb1cfcf71b8fa2e4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 765efbcf-7ca1-7734-88ed-cc8ab6ba4923
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 765efbcf7ca1773488edcc8ab6ba4923, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 7c430ff1-4341-f8a4-0b9f-26b20cbcf2dc
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 7c430ff14341f8a40b9f26b20cbcf2dc, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 848c1453-f717-7fb4-6a18-dff735a5fdc4
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 848c1453f7177fb46a18dff735a5fdc4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8ae8d019-d054-0b44-e80d-623f6ca47d64
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 8ae8d019d0540b44e80d623f6ca47d64, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 9d90886b-b664-6244-e852-a0acb1de3a3b
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: 9d90886bb6646244e852a0acb1de3a3b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ac992f1e-c8cf-ba14-5b10-655b334ec711
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: ac992f1ec8cfba145b10655b334ec711, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bdc1f15a-0c97-6854-780a-dcd7e56cfb3e
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: bdc1f15a0c976854780adcd7e56cfb3e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e35ddb0c-8710-c294-9a37-a6975f6847db
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: e35ddb0c8710c2949a37a6975f6847db, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ec33d8a6-027c-1574-3908-12966f8aef94
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: ec33d8a6027c1574390812966f8aef94, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ee0cdf44-9e9b-c854-f919-aa6826ce6ab8
+      fileIdentifier: 8300000
+    Asset: {fileID: 8300000, guid: ee0cdf449e9bc854f919aa6826ce6ab8, type: 3}

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/DefaultStateSynchronizationPerformanceParameters.prefab
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/DefaultStateSynchronizationPerformanceParameters.prefab
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3626786713139886828
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1501372582092350791}
+  - component: {fileID: 3610638268723020949}
+  m_Layer: 0
+  m_Name: DefaultStateSynchronizationPerformanceParameters
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1501372582092350791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3626786713139886828}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3610638268723020949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3626786713139886828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e476078f139b76b4bb5abc31ec92b582, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  checkForComponentBroadcasters: 2
+  shaderKeywords: 2
+  renderQueue: 2
+  materialProperties: 2
+  materialPropertyOverrides: []
+  materialPropertyBlocks: 1

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/DefaultStateSynchronizationPerformanceParameters.prefab.meta
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/DefaultStateSynchronizationPerformanceParameters.prefab.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 2f841b7408119bb42b918a5dccfc9c0b
-folderAsset: yes
-DefaultImporter:
+guid: f611f4d9158ce53409c9f30f2b63acf4
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/FontAssetCache.asset
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/FontAssetCache.asset
@@ -14,20 +14,32 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: 85f238ec-2c6a-4eef-91c4-f846cf5aa952
-    Asset: {fileID: 12800000, guid: a99e8b1ed1154eb58270cc6a18605657, type: 3}
-  - AssetId:
-      m_storage: 4f3011db-01ba-4b44-abfa-c216be5501e4
-    Asset: {fileID: 12800000, guid: e48b920555144c6da3ee2ab03f0fda88, type: 3}
-  - AssetId:
-      m_storage: 1b8dd45b-6d73-4129-9050-e26e525538d0
-    Asset: {fileID: 12800000, guid: 0fd94703e1ea496bb9999216ac3ece0d, type: 3}
-  - AssetId:
-      m_storage: b7ab8c2e-a572-4554-8d17-d5cc69983269
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10102
     Asset: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: c2d6f7aa-a870-4984-8f26-066992de962e
-    Asset: {fileID: 12800000, guid: e869342c56e54acf989b2422b4b80dcc, type: 3}
+      guid:
+        m_storage: 0fd94703-e1ea-496b-b999-9216ac3ece0d
+      fileIdentifier: 12800000
+    Asset: {fileID: 12800000, guid: 0fd94703e1ea496bb9999216ac3ece0d, type: 3}
   - AssetId:
-      m_storage: f645d01c-a1de-4f2c-bb78-b17a04917c3e
+      guid:
+        m_storage: a99e8b1e-d115-4eb5-8270-cc6a18605657
+      fileIdentifier: 12800000
+    Asset: {fileID: 12800000, guid: a99e8b1ed1154eb58270cc6a18605657, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e48b9205-5514-4c6d-a3ee-2ab03f0fda88
+      fileIdentifier: 12800000
+    Asset: {fileID: 12800000, guid: e48b920555144c6da3ee2ab03f0fda88, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e65983ad-3f7b-44aa-81e7-26d5ffb472d7
+      fileIdentifier: 12800000
     Asset: {fileID: 12800000, guid: e65983ad3f7b44aa81e726d5ffb472d7, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e869342c-56e5-4acf-989b-2422b4b80dcc
+      fileIdentifier: 12800000
+    Asset: {fileID: 12800000, guid: e869342c56e54acf989b2422b4b80dcc, type: 3}

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MaterialPropertyAssetCache.asset
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MaterialPropertyAssetCache.asset
@@ -131,6 +131,10 @@ MonoBehaviour:
     propertyType: 2
   - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
     shaderName: Mixed Reality Toolkit/Standard
+    propertyName: _BlendedClippingWidth
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+    shaderName: Mixed Reality Toolkit/Standard
     propertyName: _ClippingBorder
     propertyType: 2
   - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
@@ -179,8 +183,32 @@ MonoBehaviour:
     propertyType: 2
   - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
     shaderName: Mixed Reality Toolkit/Standard
+    propertyName: _EnableProximityLightColorOverride
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+    shaderName: Mixed Reality Toolkit/Standard
+    propertyName: _ProximityLightCenterColorOverride
+    propertyType: 0
+  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+    shaderName: Mixed Reality Toolkit/Standard
+    propertyName: _ProximityLightMiddleColorOverride
+    propertyType: 0
+  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+    shaderName: Mixed Reality Toolkit/Standard
+    propertyName: _ProximityLightOuterColorOverride
+    propertyType: 0
+  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+    shaderName: Mixed Reality Toolkit/Standard
+    propertyName: _ProximityLightSubtractive
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+    shaderName: Mixed Reality Toolkit/Standard
     propertyName: _ProximityLightTwoSided
     propertyType: 2
+  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+    shaderName: Mixed Reality Toolkit/Standard
+    propertyName: _FluentLightIntensity
+    propertyType: 3
   - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
     shaderName: Mixed Reality Toolkit/Standard
     propertyName: _RoundCorners
@@ -489,6 +517,10 @@ MonoBehaviour:
     shaderName: Mixed Reality Toolkit/TextMeshPro
     propertyName: _ColorMask
     propertyType: 2
+  - shader: {fileID: 4800000, guid: 1c504b73bf66872479cd1215fb5ce0fe, type: 3}
+    shaderName: Mixed Reality Toolkit/TextMeshPro
+    propertyName: _ZWrite
+    propertyType: 2
   - shader: {fileID: 207, guid: 0000000000000000f000000000000000, type: 0}
     shaderName: Legacy Shaders/Particles/Alpha Blended Premultiply
     propertyName: _MainTex
@@ -497,6 +529,158 @@ MonoBehaviour:
     shaderName: Legacy Shaders/Particles/Alpha Blended Premultiply
     propertyName: _InvFade
     propertyType: 3
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _Cull
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _Color
+    propertyType: 0
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _StencilComp
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _Stencil
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _StencilOp
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _StencilWriteMask
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _StencilReadMask
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
+    shaderName: Mixed Reality Toolkit/Text3DShader
+    propertyName: _ColorMask
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _Color
+    propertyType: 0
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _Cutoff
+    propertyType: 3
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _Glossiness
+    propertyType: 3
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _GlossMapScale
+    propertyType: 3
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _SmoothnessTextureChannel
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _Metallic
+    propertyType: 3
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _MetallicGlossMap
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _SpecularHighlights
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _GlossyReflections
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _BumpScale
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _BumpMap
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _Parallax
+    propertyType: 3
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _ParallaxMap
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _OcclusionStrength
+    propertyType: 3
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _OcclusionMap
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _EmissionColor
+    propertyType: 0
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _EmissionMap
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _DetailMask
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _DetailAlbedoMap
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _DetailNormalMapScale
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _DetailNormalMap
+    propertyType: 4
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _UVSec
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _Mode
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _SrcBlend
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _DstBlend
+    propertyType: 2
+  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Standard
+    propertyName: _ZWrite
+    propertyType: 2
+  - shader: {fileID: 10101, guid: 0000000000000000e000000000000000, type: 0}
+    shaderName: GUI/Text Shader
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 10101, guid: 0000000000000000e000000000000000, type: 0}
+    shaderName: GUI/Text Shader
+    propertyName: _Color
+    propertyType: 0
   - shader: {fileID: 4800000, guid: fe393ace9b354375a9cb14cdbbc28be4, type: 3}
     shaderName: TextMeshPro/Mobile/Distance Field
     propertyName: _FaceColor
@@ -631,158 +815,6 @@ MonoBehaviour:
     propertyType: 2
   - shader: {fileID: 4800000, guid: fe393ace9b354375a9cb14cdbbc28be4, type: 3}
     shaderName: TextMeshPro/Mobile/Distance Field
-    propertyName: _ColorMask
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _Color
-    propertyType: 0
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _Cutoff
-    propertyType: 3
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _Glossiness
-    propertyType: 3
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _GlossMapScale
-    propertyType: 3
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _SmoothnessTextureChannel
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _Metallic
-    propertyType: 3
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _MetallicGlossMap
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _SpecularHighlights
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _GlossyReflections
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _BumpScale
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _BumpMap
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _Parallax
-    propertyType: 3
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _ParallaxMap
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _OcclusionStrength
-    propertyType: 3
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _OcclusionMap
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _EmissionColor
-    propertyType: 0
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _EmissionMap
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _DetailMask
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _DetailAlbedoMap
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _DetailNormalMapScale
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _DetailNormalMap
-    propertyType: 4
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _UVSec
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _Mode
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _SrcBlend
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _DstBlend
-    propertyType: 2
-  - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Standard
-    propertyName: _ZWrite
-    propertyType: 2
-  - shader: {fileID: 10101, guid: 0000000000000000e000000000000000, type: 0}
-    shaderName: GUI/Text Shader
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 10101, guid: 0000000000000000e000000000000000, type: 0}
-    shaderName: GUI/Text Shader
-    propertyName: _Color
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _Cull
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _Color
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _StencilComp
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _Stencil
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _StencilOp
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _StencilWriteMask
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
-    propertyName: _StencilReadMask
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 80c006b91733f1a4991c49af89321ecd, type: 3}
-    shaderName: Mixed Reality Toolkit/Text3DShader
     propertyName: _ColorMask
     propertyType: 2
   - shader: {fileID: 4800000, guid: b9a74a6dfafb45b419d9e91a08b9b335, type: 3}
@@ -1293,6 +1325,66 @@ MonoBehaviour:
     shaderName: TextMeshPro/Distance Field
     propertyName: _ColorMask
     propertyType: 2
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Proximity_Distance_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Fade_Near_Distance_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Fade_Far_Distance_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Shrink_Start_Distance_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Near_Radius_Fraction_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Far_Center_Fraction_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Near_Center_Fraction_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Thickness_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Rise_Start_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Rise_End_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Fall_Start_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Fall_End_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Start_Fall_Fade_
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Edge_Color_
+    propertyType: 0
+  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
+    shaderName: Mixed Reality Toolkit/FingerTipCursor
+    propertyName: _Base_Color_
+    propertyType: 0
   - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
     shaderName: UI/Default
     propertyName: _MainTex
@@ -1475,202 +1567,6 @@ MonoBehaviour:
     propertyType: 2
   - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
     shaderName: Mixed Reality Toolkit/Wireframe
-    propertyName: _BaseColor
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
-    shaderName: Mixed Reality Toolkit/Wireframe
-    propertyName: _WireColor
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
-    shaderName: Mixed Reality Toolkit/Wireframe
-    propertyName: _WireThickness
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
-    shaderName: SV/RGBToYUV
-    propertyName: _RGBTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
-    shaderName: SV/RGBToYUV
-    propertyName: _Width
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
-    shaderName: SV/RGBToYUV
-    propertyName: _Height
-    propertyType: 2
-  - shader: {fileID: 1, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Legacy Shaders/Diffuse Fast
-    propertyName: _Color
-    propertyType: 0
-  - shader: {fileID: 1, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: Legacy Shaders/Diffuse Fast
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: acab126297274c848beb9908fb34d939, type: 3}
-    shaderName: SV/Downsample
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: acab126297274c848beb9908fb34d939, type: 3}
-    shaderName: SV/Downsample
-    propertyName: _HeightOffset
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: acab126297274c848beb9908fb34d939, type: 3}
-    shaderName: SV/Downsample
-    propertyName: _WidthOffset
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: c8a28ad8c8326d048a8a0af8fa87e004, type: 3}
-    shaderName: SV/HoloAlpha
-    propertyName: _BackTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: c8a28ad8c8326d048a8a0af8fa87e004, type: 3}
-    shaderName: SV/HoloAlpha
-    propertyName: _FronTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: c8a28ad8c8326d048a8a0af8fa87e004, type: 3}
-    shaderName: SV/HoloAlpha
-    propertyName: _Alpha
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
-    shaderName: SV/YUVToRGB
-    propertyName: _YUVTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
-    shaderName: SV/YUVToRGB
-    propertyName: _Width
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
-    shaderName: SV/YUVToRGB
-    propertyName: _Height
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
-    shaderName: SV/YUVToRGB
-    propertyName: _AlphaScale
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
-    shaderName: SV/RGBToNV12
-    propertyName: _RGBTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
-    shaderName: SV/RGBToNV12
-    propertyName: _Width
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
-    shaderName: SV/RGBToNV12
-    propertyName: _Height
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 85fad1b1898fc6c43b34ef1668215c99, type: 3}
-    shaderName: SV/ExtractAlpha
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: ea4b73caa6ce81141a44be6d0a0c6829, type: 3}
-    shaderName: SV/IgnoreAlpha
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
-    shaderName: SV/BGRToRGB
-    propertyName: _FlipTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
-    shaderName: SV/BGRToRGB
-    propertyName: _AlphaScale
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
-    shaderName: SV/BGRToRGB
-    propertyName: _YFlip
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
-    shaderName: Mixed Reality Toolkit/Standard
-    propertyName: _BlendedClippingWidth
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
-    shaderName: Mixed Reality Toolkit/Standard
-    propertyName: _EnableProximityLightColorOverride
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
-    shaderName: Mixed Reality Toolkit/Standard
-    propertyName: _ProximityLightCenterColorOverride
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
-    shaderName: Mixed Reality Toolkit/Standard
-    propertyName: _ProximityLightMiddleColorOverride
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
-    shaderName: Mixed Reality Toolkit/Standard
-    propertyName: _ProximityLightOuterColorOverride
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
-    shaderName: Mixed Reality Toolkit/Standard
-    propertyName: _ProximityLightSubtractive
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
-    shaderName: Mixed Reality Toolkit/Standard
-    propertyName: _FluentLightIntensity
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 1c504b73bf66872479cd1215fb5ce0fe, type: 3}
-    shaderName: Mixed Reality Toolkit/TextMeshPro
-    propertyName: _ZWrite
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Proximity_Distance_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Fade_Near_Distance_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Fade_Far_Distance_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Shrink_Start_Distance_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Near_Radius_Fraction_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Far_Center_Fraction_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Near_Center_Fraction_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Thickness_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Rise_Start_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Rise_End_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Fall_Start_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Fall_End_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Start_Fall_Fade_
-    propertyType: 3
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Edge_Color_
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 713bac42f937fad4da6ed48657c681c8, type: 3}
-    shaderName: Mixed Reality Toolkit/FingerTipCursor
-    propertyName: _Base_Color_
-    propertyType: 0
-  - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
-    shaderName: Mixed Reality Toolkit/Wireframe
     propertyName: _Mode
     propertyType: 2
   - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
@@ -1717,3 +1613,135 @@ MonoBehaviour:
     shaderName: Mixed Reality Toolkit/Wireframe
     propertyName: _RenderQueueOverride
     propertyType: 3
+  - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
+    shaderName: Mixed Reality Toolkit/Wireframe
+    propertyName: _BaseColor
+    propertyType: 0
+  - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
+    shaderName: Mixed Reality Toolkit/Wireframe
+    propertyName: _WireColor
+    propertyType: 0
+  - shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
+    shaderName: Mixed Reality Toolkit/Wireframe
+    propertyName: _WireThickness
+    propertyType: 3
+  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
+    shaderName: SV/RGBToYUV
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
+    shaderName: SV/RGBToYUV
+    propertyName: _Width
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
+    shaderName: SV/RGBToYUV
+    propertyName: _Height
+    propertyType: 2
+  - shader: {fileID: 1, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Legacy Shaders/Diffuse Fast
+    propertyName: _Color
+    propertyType: 0
+  - shader: {fileID: 1, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: Legacy Shaders/Diffuse Fast
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
+    shaderName: SV/AlphaBlend
+    propertyName: _BackTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
+    shaderName: SV/AlphaBlend
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
+    shaderName: SV/AlphaBlend
+    propertyName: _Alpha
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: acab126297274c848beb9908fb34d939, type: 3}
+    shaderName: SV/Downsample
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: acab126297274c848beb9908fb34d939, type: 3}
+    shaderName: SV/Downsample
+    propertyName: _HeightOffset
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: acab126297274c848beb9908fb34d939, type: 3}
+    shaderName: SV/Downsample
+    propertyName: _WidthOffset
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: c8a28ad8c8326d048a8a0af8fa87e004, type: 3}
+    shaderName: SV/HoloAlpha
+    propertyName: _BackTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: c8a28ad8c8326d048a8a0af8fa87e004, type: 3}
+    shaderName: SV/HoloAlpha
+    propertyName: _FronTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: c8a28ad8c8326d048a8a0af8fa87e004, type: 3}
+    shaderName: SV/HoloAlpha
+    propertyName: _Alpha
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 941c5282fb189a4488e0e77278feab21, type: 3}
+    shaderName: SV/QuadView
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 941c5282fb189a4488e0e77278feab21, type: 3}
+    shaderName: SV/QuadView
+    propertyName: _HologramTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 941c5282fb189a4488e0e77278feab21, type: 3}
+    shaderName: SV/QuadView
+    propertyName: _HologramAlphaTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 941c5282fb189a4488e0e77278feab21, type: 3}
+    shaderName: SV/QuadView
+    propertyName: _CompositeTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
+    shaderName: SV/YUVToRGB
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
+    shaderName: SV/YUVToRGB
+    propertyName: _Width
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
+    shaderName: SV/YUVToRGB
+    propertyName: _Height
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
+    shaderName: SV/YUVToRGB
+    propertyName: _AlphaScale
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
+    shaderName: SV/RGBToNV12
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
+    shaderName: SV/RGBToNV12
+    propertyName: _Width
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
+    shaderName: SV/RGBToNV12
+    propertyName: _Height
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 85fad1b1898fc6c43b34ef1668215c99, type: 3}
+    shaderName: SV/ExtractAlpha
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: ea4b73caa6ce81141a44be6d0a0c6829, type: 3}
+    shaderName: SV/IgnoreAlpha
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
+    shaderName: SV/BGRToRGB
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
+    shaderName: SV/BGRToRGB
+    propertyName: _AlphaScale
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
+    shaderName: SV/BGRToRGB
+    propertyName: _YFlip
+    propertyType: 2

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MeshAssetCache.asset
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MeshAssetCache.asset
@@ -14,293 +14,452 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: 2832407a-d32e-43ee-b559-7d62523485c6
-    Asset: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
-  - AssetId:
-      m_storage: 6493aa1a-c747-4bbd-a270-6696bbfccff8
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10202
     Asset: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 12ca2e45-7aec-4ad2-9ac6-b9046b8cba35
-    Asset: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
-  - AssetId:
-      m_storage: 7ff06b4a-3c70-4eb1-bf71-9a60047a5084
-    Asset: {fileID: 4300010, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: 30a9ce1c-7059-4c9f-955e-0422ac89adcd
-    Asset: {fileID: 4300000, guid: 15c4f2d8e761dd34a9cdbae9c6a96bbb, type: 3}
-  - AssetId:
-      m_storage: 97882cb1-23e7-4e27-9980-cd42820f3be2
-    Asset: {fileID: 4300014, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: d3fbb56d-5ebb-4581-96c6-d20a4e41b687
-    Asset: {fileID: 4300010, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: 454003af-aa20-414b-8119-cdc0faea3291
-    Asset: {fileID: 4300008, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: e9508a83-4612-42df-b6a4-36db32e6e653
-    Asset: {fileID: 4300002, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: 9ad47724-c80f-46ec-babc-c95a5fbfcb62
-    Asset: {fileID: 4300000, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: 1734adb6-67a3-493e-bc9e-7d997d2d90ca
-    Asset: {fileID: 4300012, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: 1d351d0f-14bb-4bd8-8f06-9aba44f65b80
-    Asset: {fileID: 4300006, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: 8d0eee52-c504-443f-a104-25e982ba664e
-    Asset: {fileID: 4300004, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
-  - AssetId:
-      m_storage: 9d5c93c6-d68d-4b45-8205-f4b8913418f3
-    Asset: {fileID: 4300006, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 39e06d01-71a3-403d-bb61-7d4f65300ab0
-    Asset: {fileID: 4300008, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 13403ee8-dac9-47be-9ac8-6f7bf1f75f09
-    Asset: {fileID: 4300004, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 46754fcb-d581-47fb-8bdc-4c13d57a3261
-    Asset: {fileID: 4300010, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: a4592e0f-505e-40db-bc22-5097660e8606
-    Asset: {fileID: 4300020, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: b27b58ec-4e8e-47a7-b60c-ef250b672b04
-    Asset: {fileID: 4300024, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 4768f242-8618-40d8-8777-ffd3a82106cc
-    Asset: {fileID: 4300028, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 1e284916-add3-4937-87e7-7faed9cfa00a
-    Asset: {fileID: 4300022, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 22c05f18-d7a9-4ba4-ba1a-8f949b16b1b7
-    Asset: {fileID: 4300002, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 9889b84b-16c7-4d72-b42f-a0031edb134f
-    Asset: {fileID: 4300030, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 2f8ac0b1-2ea9-4ac0-9f7a-370b82218527
-    Asset: {fileID: 4300018, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 6342ea88-2369-48a7-b3c6-e2b5ee527395
-    Asset: {fileID: 4300000, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 996d5ff6-f9d8-4c0d-9cd5-4710ccbdf2b2
-    Asset: {fileID: 4300026, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: e7ce56b2-aa61-489c-bde3-6d16abad7630
-    Asset: {fileID: 4300012, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 13f11777-0ce2-44f0-bdf7-fe94e7f02f78
-    Asset: {fileID: 4300014, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: 9399c0ef-b979-4723-8457-90507afafc67
-    Asset: {fileID: 4300000, guid: 996a0d311bfdb2141a2b73de067df64d, type: 3}
-  - AssetId:
-      m_storage: 681776a2-5325-4d4b-85d4-35d8a4f20b7b
-    Asset: {fileID: 4300000, guid: fa3a0f81e3a63bd4db13ad99b3858f49, type: 3}
-  - AssetId:
-      m_storage: d8406588-1256-43d7-b96d-87b62f217c5d
-    Asset: {fileID: 4300000, guid: 164467aaab0440cbb011a7c287072878, type: 3}
-  - AssetId:
-      m_storage: 78b29254-3503-4475-a64c-4bcd1bd2bbb2
-    Asset: {fileID: 4300000, guid: 83bc58c16aef8bf4f88c3cb9d55966be, type: 3}
-  - AssetId:
-      m_storage: af63b22c-e2ce-488a-b396-4be6face07b3
-    Asset: {fileID: 4300004, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 75b07d39-9acf-40f5-8dd8-5bca7a1aa613
-    Asset: {fileID: 4300010, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: c95e2e10-339f-458c-80f3-fa40873acf1a
-    Asset: {fileID: 4300006, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 83897120-b69c-4088-85ec-17c83656510c
-    Asset: {fileID: 4300012, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: f393d4c6-a648-4438-b3d1-4416edbc03cc
-    Asset: {fileID: 4300022, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: fca61c85-97c0-4873-9475-b6ca8ae6330c
-    Asset: {fileID: 4300026, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: fac3fd0a-72e9-4070-8e07-71d1bec134a1
-    Asset: {fileID: 4300030, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 2b42a715-37d6-48e8-b7fb-67aa39ce9b80
-    Asset: {fileID: 4300024, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 874ba470-c5e5-4784-8228-5652d185eac1
-    Asset: {fileID: 4300002, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: f763eeb1-1ee8-47a7-98d9-e4015f1e5e37
-    Asset: {fileID: 4300034, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 7e81d5a9-b529-40fd-baea-7d99b6804f28
-    Asset: {fileID: 4300020, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: b2257766-a5ca-4c30-a302-c5010cda4706
-    Asset: {fileID: 4300000, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 1e7bae95-0fb7-481f-8605-840611882cd3
-    Asset: {fileID: 4300028, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: a9e13778-714a-4c19-9ab8-c8622b7a1130
-    Asset: {fileID: 4300014, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: c933a25a-c5d4-4d88-8f65-cf492f49e69b
-    Asset: {fileID: 4300016, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 0ca39bc3-71b6-4216-b06f-75d52778bda0
-    Asset: {fileID: 4300000, guid: b57251626be6f304a83b681a561394eb, type: 3}
-  - AssetId:
-      m_storage: dfbe2a8a-4a4d-4583-b6df-3970cc2fcd96
-    Asset: {fileID: 4300000, guid: 57c53da2552a8114ab6d68e0cd31b1eb, type: 3}
-  - AssetId:
-      m_storage: 1681ff04-9e37-4154-9609-024ec4ddc4cc
-    Asset: {fileID: 4300000, guid: 555e9d637afc1bb4588b164af67be209, type: 3}
-  - AssetId:
-      m_storage: 798be2d5-07a2-42b2-81cc-83a4f905f6ce
-    Asset: {fileID: 4300018, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
-  - AssetId:
-      m_storage: 5cef3397-c7a2-4af5-a4d7-8d0473b741d8
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10206
     Asset: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 1a5d3cac-56c8-4cbd-97fb-4bab9a6cb4dc
-    Asset: {fileID: 4300000, guid: 16afe3fd2a3c4d2c85aeeb732ae7f9fb, type: 3}
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10207
+    Asset: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 0a3e5e0b-aa22-40a0-aded-ddf6c4048101
-    Asset: {fileID: 4300000, guid: 8881ed45b1c1d9c45b0f99ba2730ee66, type: 3}
-  - AssetId:
-      m_storage: ee60f2ea-84fd-4fa0-b978-abc3c79e3179
-    Asset: {fileID: 4300000, guid: ce4cfb5a16c86b048bb700360ee47685, type: 3}
-  - AssetId:
-      m_storage: 3ef229d7-8f49-4e2d-ab54-32e672188549
-    Asset: {fileID: 4300000, guid: 22a8495610f36594ebf91bc92e5579c7, type: 3}
-  - AssetId:
-      m_storage: e43d7874-1315-4195-b982-3012e0981c03
-    Asset: {fileID: 4300002, guid: c5ea4fd8e9ae28b4589fd0af019bce06, type: 3}
-  - AssetId:
-      m_storage: b493a462-4125-41cb-9e75-66c70be37ba4
-    Asset: {fileID: 4300000, guid: 63df887775f744ff81b5498f43f24074, type: 3}
-  - AssetId:
-      m_storage: 3ff8888c-6ca5-4cdb-83d0-e2c5fd875eba
-    Asset: {fileID: 4300002, guid: 63df887775f744ff81b5498f43f24074, type: 3}
-  - AssetId:
-      m_storage: 5f70fe28-8c2d-4e84-9c57-eab9eda46d17
-    Asset: {fileID: 4300004, guid: 63df887775f744ff81b5498f43f24074, type: 3}
-  - AssetId:
-      m_storage: f36e6856-c424-4b01-b609-8a9fdedab0a5
-    Asset: {fileID: 4300000, guid: dcbc8487c29e12c44ba6661fb1afbe6c, type: 3}
-  - AssetId:
-      m_storage: b4bbed97-0772-43a5-9bbf-74879b86d081
-    Asset: {fileID: 4300000, guid: a6473ac7ac982fb488db53a454bf0a3c, type: 3}
-  - AssetId:
-      m_storage: 511b6f20-ddd4-4605-bcda-fd91cef37f4f
-    Asset: {fileID: 4300000, guid: caf154e80e62ac7439f2b35a96114c28, type: 3}
-  - AssetId:
-      m_storage: 7dfed8a6-943d-4c45-a4ee-29a8a534bb1b
-    Asset: {fileID: 4300000, guid: 1f927d8a23ccb6443b8eb9990f48070b, type: 3}
-  - AssetId:
-      m_storage: ecb0513b-d2bd-42e9-ae45-aba0ad13b588
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10209
     Asset: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 7b06926a-530e-4677-89c7-e110840f4735
-    Asset: {fileID: 4300000, guid: 968d2afac55bd06469d22c1563df5855, type: 3}
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10210
+    Asset: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 9a66b11e-40ad-496f-a718-b13cf7d8022e
-    Asset: {fileID: 4300000, guid: 3f1525ceb67261b429bc8741e7cee099, type: 3}
+      guid:
+        m_storage: 15c4f2d8-e761-dd34-a9cd-bae9c6a96bbb
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 15c4f2d8e761dd34a9cdbae9c6a96bbb, type: 3}
   - AssetId:
-      m_storage: 7651dfc0-022e-4893-b5ad-ac0ddbd5fa48
-    Asset: {fileID: 4300012, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+      guid:
+        m_storage: 164467aa-ab04-40cb-b011-a7c287072878
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 164467aaab0440cbb011a7c287072878, type: 3}
   - AssetId:
-      m_storage: aa4e76e6-8ead-4c19-a16d-d1dc46e2be61
-    Asset: {fileID: 4300008, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+      guid:
+        m_storage: 16afe3fd-2a3c-4d2c-85ae-eb732ae7f9fb
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 16afe3fd2a3c4d2c85aeeb732ae7f9fb, type: 3}
   - AssetId:
-      m_storage: 17cae4d6-d0a0-41b7-96d6-d71ecf6e72a9
-    Asset: {fileID: 4300000, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+      guid:
+        m_storage: 1f927d8a-23cc-b644-3b8e-b9990f48070b
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 1f927d8a23ccb6443b8eb9990f48070b, type: 3}
   - AssetId:
-      m_storage: bec68682-2c5c-4d72-a8e4-9daa0e6fa09a
-    Asset: {fileID: 4300004, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+      guid:
+        m_storage: 22a84956-10f3-6594-ebf9-1bc92e5579c7
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 22a8495610f36594ebf91bc92e5579c7, type: 3}
   - AssetId:
-      m_storage: a3cd5efe-f1ab-43be-97e2-6ae38a70b2bc
-    Asset: {fileID: 4300012, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: f17b1127-d2be-4c20-a186-d8ac195bf883
-    Asset: {fileID: 4300014, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: 071695f4-025d-41a9-8d83-f89071d9c3b9
-    Asset: {fileID: 4300016, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: f2d01b90-be25-4788-83cb-c315b93141d7
-    Asset: {fileID: 4300000, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: 89c0c7e6-b75c-4896-bd19-4d82a57314df
-    Asset: {fileID: 4300002, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: 1a737fdf-a3b1-4067-97c6-cb7266f39c4f
-    Asset: {fileID: 4300004, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: 12e9c48d-1043-4d24-9108-3f9211cbc6f3
-    Asset: {fileID: 4300006, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: 0d75cb64-f7c4-4a87-b762-d74afcac8279
-    Asset: {fileID: 4300008, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: b4ef3c7c-bf60-4966-af6a-d1756fcb097b
-    Asset: {fileID: 4300018, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
-  - AssetId:
-      m_storage: 2b8341d5-a6e2-42ef-9f02-d4f060e17142
-    Asset: {fileID: 4300000, guid: e77cfaaf40f5edc4e901d584e08f0cf0, type: 3}
-  - AssetId:
-      m_storage: 026f5b5e-b3fa-49c1-8deb-88fc9df2653e
-    Asset: {fileID: 4300016, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
-  - AssetId:
-      m_storage: c05e8c9c-276a-4d20-873a-668fa7a9da6a
-    Asset: {fileID: 4300002, guid: ceae3a0d54734302818fcee506300fef, type: 3}
-  - AssetId:
-      m_storage: a86b4508-959a-4309-bf09-5f0d2191d1bb
-    Asset: {fileID: 4300014, guid: ceae3a0d54734302818fcee506300fef, type: 3}
-  - AssetId:
-      m_storage: ca40492a-3830-40c3-97e2-e1ac0e539c6b
-    Asset: {fileID: 4300010, guid: ceae3a0d54734302818fcee506300fef, type: 3}
-  - AssetId:
-      m_storage: 87c5324c-8fd4-4082-88fc-6d5d4e81a6d2
-    Asset: {fileID: 4300006, guid: ceae3a0d54734302818fcee506300fef, type: 3}
-  - AssetId:
-      m_storage: 7a41c265-7082-4c9a-aaf8-21e5279fec4c
-    Asset: {fileID: 4300000, guid: feb050428dc7b2d4fa247e8d11bf1eaf, type: 3}
-  - AssetId:
-      m_storage: 198d35f6-6a5d-48a1-bb0d-a6c0e13284e7
-    Asset: {fileID: 4300000, guid: b1b91cc294648bc4da669c0dc8ed7a43, type: 3}
-  - AssetId:
-      m_storage: 60db3eb8-6178-411f-ae6e-fd6eba0fce1b
-    Asset: {fileID: 4300000, guid: 53f3b56542efab947876d4aae08d36c2, type: 3}
-  - AssetId:
-      m_storage: 3b9ab75b-ff81-427c-a38a-0b7562823379
+      guid:
+        m_storage: 36fc2837-fda8-9a64-7990-5d3bc90d9ff8
+      fileIdentifier: 4300000
     Asset: {fileID: 4300000, guid: 36fc2837fda89a6479905d3bc90d9ff8, type: 3}
   - AssetId:
-      m_storage: 28dcd58d-7b6d-4112-961a-493c4c6db1a3
-    Asset: {fileID: 0}
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
   - AssetId:
-      m_storage: 2f44e608-34d8-4edd-ba4a-242df3b5e279
-    Asset: {fileID: 0}
+      guid:
+        m_storage: 3f1525ce-b672-61b4-29bc-8741e7cee099
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 3f1525ceb67261b429bc8741e7cee099, type: 3}
   - AssetId:
-      m_storage: 34268d1c-48af-40e8-95fe-96ff22c00633
-    Asset: {fileID: 0}
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
   - AssetId:
-      m_storage: dc386465-8828-4c41-8783-69ca5f9b3665
-    Asset: {fileID: 0}
+      guid:
+        m_storage: 53f3b565-42ef-ab94-7876-d4aae08d36c2
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 53f3b56542efab947876d4aae08d36c2, type: 3}
   - AssetId:
-      m_storage: 5ce4b19e-65e0-45c2-8fc9-2094e363d59b
-    Asset: {fileID: 0}
+      guid:
+        m_storage: 555e9d63-7afc-1bb4-588b-164af67be209
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 555e9d637afc1bb4588b164af67be209, type: 3}
   - AssetId:
-      m_storage: b1b7a3f5-d413-4a4e-a363-fa148b2a3dca
-    Asset: {fileID: 0}
+      guid:
+        m_storage: 57c53da2-552a-8114-ab6d-68e0cd31b1eb
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 57c53da2552a8114ab6d68e0cd31b1eb, type: 3}
   - AssetId:
-      m_storage: 3bf0f741-b6a0-493b-9cbf-7c78a746805a
-    Asset: {fileID: 0}
+      guid:
+        m_storage: 63df8877-75f7-44ff-81b5-498f43f24074
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 63df887775f744ff81b5498f43f24074, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 83bc58c1-6aef-8bf4-f88c-3cb9d55966be
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 83bc58c16aef8bf4f88c3cb9d55966be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8881ed45-b1c1-d9c4-5b0f-99ba2730ee66
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 8881ed45b1c1d9c45b0f99ba2730ee66, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 968d2afa-c55b-d064-69d2-2c1563df5855
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 968d2afac55bd06469d22c1563df5855, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 996a0d31-1bfd-b214-1a2b-73de067df64d
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: 996a0d311bfdb2141a2b73de067df64d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a6473ac7-ac98-2fb4-88db-53a454bf0a3c
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: a6473ac7ac982fb488db53a454bf0a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b1b91cc2-9464-8bc4-da66-9c0dc8ed7a43
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: b1b91cc294648bc4da669c0dc8ed7a43, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b5725162-6be6-f304-a83b-681a561394eb
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: b57251626be6f304a83b681a561394eb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: caf154e8-0e62-ac74-39f2-b35a96114c28
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: caf154e80e62ac7439f2b35a96114c28, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ce4cfb5a-16c8-6b04-8bb7-00360ee47685
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: ce4cfb5a16c86b048bb700360ee47685, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: dcbc8487-c29e-12c4-4ba6-661fb1afbe6c
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: dcbc8487c29e12c44ba6661fb1afbe6c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e77cfaaf-40f5-edc4-e901-d584e08f0cf0
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: e77cfaaf40f5edc4e901d584e08f0cf0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fa3a0f81-e3a6-3bd4-db13-ad99b3858f49
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: fa3a0f81e3a63bd4db13ad99b3858f49, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: feb05042-8dc7-b2d4-fa24-7e8d11bf1eaf
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: feb050428dc7b2d4fa247e8d11bf1eaf, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300002
+    Asset: {fileID: 4300002, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300002
+    Asset: {fileID: 4300002, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 63df8877-75f7-44ff-81b5-498f43f24074
+      fileIdentifier: 4300002
+    Asset: {fileID: 4300002, guid: 63df887775f744ff81b5498f43f24074, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300002
+    Asset: {fileID: 4300002, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c5ea4fd8-e9ae-28b4-589f-d0af019bce06
+      fileIdentifier: 4300002
+    Asset: {fileID: 4300002, guid: c5ea4fd8e9ae28b4589fd0af019bce06, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300002
+    Asset: {fileID: 4300002, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300002
+    Asset: {fileID: 4300002, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300004
+    Asset: {fileID: 4300004, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300004
+    Asset: {fileID: 4300004, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 63df8877-75f7-44ff-81b5-498f43f24074
+      fileIdentifier: 4300004
+    Asset: {fileID: 4300004, guid: 63df887775f744ff81b5498f43f24074, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300004
+    Asset: {fileID: 4300004, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300004
+    Asset: {fileID: 4300004, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300004
+    Asset: {fileID: 4300004, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300006
+    Asset: {fileID: 4300006, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300006
+    Asset: {fileID: 4300006, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300006
+    Asset: {fileID: 4300006, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300006
+    Asset: {fileID: 4300006, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300006
+    Asset: {fileID: 4300006, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300008
+    Asset: {fileID: 4300008, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300008
+    Asset: {fileID: 4300008, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300008
+    Asset: {fileID: 4300008, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300008
+    Asset: {fileID: 4300008, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300010
+    Asset: {fileID: 4300010, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300010
+    Asset: {fileID: 4300010, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300010
+    Asset: {fileID: 4300010, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300010
+    Asset: {fileID: 4300010, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300010
+    Asset: {fileID: 4300010, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300012
+    Asset: {fileID: 4300012, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300012
+    Asset: {fileID: 4300012, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300012
+    Asset: {fileID: 4300012, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300012
+    Asset: {fileID: 4300012, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300012
+    Asset: {fileID: 4300012, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d93f721-9bba-0634-a9ee-26865f9d6a3c
+      fileIdentifier: 4300014
+    Asset: {fileID: 4300014, guid: 3d93f7219bba0634a9ee26865f9d6a3c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300014
+    Asset: {fileID: 4300014, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300014
+    Asset: {fileID: 4300014, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ceae3a0d-5473-4302-818f-cee506300fef
+      fileIdentifier: 4300014
+    Asset: {fileID: 4300014, guid: ceae3a0d54734302818fcee506300fef, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300014
+    Asset: {fileID: 4300014, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300016
+    Asset: {fileID: 4300016, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300016
+    Asset: {fileID: 4300016, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300016
+    Asset: {fileID: 4300016, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300018
+    Asset: {fileID: 4300018, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b566bbce-04d6-6f44-2842-1e81a3af0299
+      fileIdentifier: 4300018
+    Asset: {fileID: 4300018, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300018
+    Asset: {fileID: 4300018, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300020
+    Asset: {fileID: 4300020, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300020
+    Asset: {fileID: 4300020, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300022
+    Asset: {fileID: 4300022, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300022
+    Asset: {fileID: 4300022, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300024
+    Asset: {fileID: 4300024, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300024
+    Asset: {fileID: 4300024, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300026
+    Asset: {fileID: 4300026, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300026
+    Asset: {fileID: 4300026, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300028
+    Asset: {fileID: 4300028, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300028
+    Asset: {fileID: 4300028, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300030
+    Asset: {fileID: 4300030, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fd9ad331-76d0-3dd4-2885-a4dce3cb38fb
+      fileIdentifier: 4300030
+    Asset: {fileID: 4300030, guid: fd9ad33176d03dd42885a4dce3cb38fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4193fb42-ca11-3454-5be0-f62926d0e9be
+      fileIdentifier: 4300034
+    Asset: {fileID: 4300034, guid: 4193fb42ca1134545be0f62926d0e9be, type: 3}

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpriteAssetCache.asset
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpriteAssetCache.asset
@@ -14,176 +14,297 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: 74fae14d-39c0-497e-ae6d-72f1f2084231
-    Asset: {fileID: 21300000, guid: d651fc00b471cfe44834a222e9433461, type: 3}
+      guid:
+        m_storage: 00000000-0000-0000-f000-000000000000
+      fileIdentifier: 10905
+    Asset: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
   - AssetId:
-      m_storage: f42bb34d-53dc-481f-bcc7-9823e4c197e7
-    Asset: {fileID: 21300000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
-  - AssetId:
-      m_storage: 30df0952-4da8-4b65-a4bf-9e2bd95db273
-    Asset: {fileID: 21300000, guid: 84643a20fa6b4fa7969ef84ad2e40992, type: 3}
-  - AssetId:
-      m_storage: e52d6769-916e-45d4-83f9-9e60a8d5fa94
-    Asset: {fileID: 21300000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
-  - AssetId:
-      m_storage: f842e9e4-deba-495b-ae69-a3b0ed76f8fd
-    Asset: {fileID: 21300000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
-  - AssetId:
-      m_storage: 091b7262-8f5c-43b5-b8a4-401a6a083eb3
-    Asset: {fileID: 21300000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
-  - AssetId:
-      m_storage: 395056aa-7f64-491e-b73b-456d289b9de3
-    Asset: {fileID: 21300000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
-  - AssetId:
-      m_storage: 11b0cc54-384a-4363-a516-78cb37b3697c
-    Asset: {fileID: 21300000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
-  - AssetId:
-      m_storage: c48ae6f2-9a63-4ebb-8beb-f609a0f00b8b
-    Asset: {fileID: 21300000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
-  - AssetId:
-      m_storage: c7fb622c-deb9-4e38-b041-36ae1855cec4
-    Asset: {fileID: 21300000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
-  - AssetId:
-      m_storage: e51c16d3-814c-4e17-bc17-b7170e831b05
-    Asset: {fileID: 21300000, guid: f2237692de9624a4692e4b0440c5f476, type: 3}
-  - AssetId:
-      m_storage: 207bf807-be6c-4f35-9c67-1c8a708ff975
-    Asset: {fileID: 21300000, guid: a7d0f692b982a754b8ae2353d5e88d64, type: 3}
-  - AssetId:
-      m_storage: b12a4dc8-90a6-4f1b-9a81-2497701f2eed
-    Asset: {fileID: 21300000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
-  - AssetId:
-      m_storage: 8a3a318c-6240-48a7-aff9-7a34ae5f6197
-    Asset: {fileID: 21300000, guid: c2c00ef21cc44bcfa09695879e0ebecd, type: 3}
-  - AssetId:
-      m_storage: 1b276a3c-1b19-4075-8a07-3dd84c128283
-    Asset: {fileID: 21300000, guid: 0b431d73cc837214fbf67cab3535f975, type: 3}
-  - AssetId:
-      m_storage: b7ddc170-8d2d-4321-a232-24c232274894
-    Asset: {fileID: 21300000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
-  - AssetId:
-      m_storage: 4b38f031-3567-4874-9c21-28e2d6d43b06
-    Asset: {fileID: 21300000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
-  - AssetId:
-      m_storage: f936f98c-201f-467b-a2ee-9eb78430b155
-    Asset: {fileID: 21300000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
-  - AssetId:
-      m_storage: a54d1215-1350-4093-aa43-b98fc6866ae3
-    Asset: {fileID: 21300000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
-  - AssetId:
-      m_storage: 2970e75b-5dae-4501-8b53-f3f0709fd69e
-    Asset: {fileID: 21300000, guid: 0ea40b842547d784082ebf2698d3f08b, type: 3}
-  - AssetId:
-      m_storage: 6b8b9634-a79a-4c49-b27a-c81f1e827dac
-    Asset: {fileID: 21300000, guid: 6588fe8449020f74488b8b667ce2f435, type: 3}
-  - AssetId:
-      m_storage: 88e14552-363c-4d53-8cd5-9d77133113c2
-    Asset: {fileID: 21300000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
-  - AssetId:
-      m_storage: 9e196a5d-d80a-4431-aab5-8dbeb467cf6c
-    Asset: {fileID: 21300000, guid: 96d001f4572ca3e4485a62e1a049524e, type: 3}
-  - AssetId:
-      m_storage: dc63b986-89db-433d-8699-c55726572b4f
-    Asset: {fileID: 21300000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
-  - AssetId:
-      m_storage: 9baa0140-ff74-421e-affd-efca8cebec4b
-    Asset: {fileID: 21300000, guid: 01e02995805eb483690380a911a657e2, type: 3}
-  - AssetId:
-      m_storage: 14e1ad32-9213-4da4-8313-71f0ffed36e6
-    Asset: {fileID: 21300000, guid: 8e8fc4c5d417b754280cd920d79a5e7f, type: 3}
-  - AssetId:
-      m_storage: 0e3938eb-0401-48b4-b677-e3efe4a1b50b
-    Asset: {fileID: 21300000, guid: 28ea40d50737d3c47af018f7f3ea24ee, type: 3}
-  - AssetId:
-      m_storage: 97072b73-692e-4433-9933-5f39e7437f90
-    Asset: {fileID: 21300000, guid: 68157127a1550704596f2546ea8893d9, type: 3}
-  - AssetId:
-      m_storage: ca1c7ed1-4bd5-4e17-8c9b-63fd2450b259
-    Asset: {fileID: 21300000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
-  - AssetId:
-      m_storage: b5d6e1e2-3f44-45ef-9d23-fd067de115ac
-    Asset: {fileID: 21300000, guid: d7776e47f36f995458a92021b99f44d5, type: 3}
-  - AssetId:
-      m_storage: 70505db5-7499-4054-9ad5-3fdc1ce69379
-    Asset: {fileID: 21300000, guid: 375eed972162232439848c636aab9117, type: 3}
-  - AssetId:
-      m_storage: e93255ae-3906-416f-95d6-420e31ef4ffb
-    Asset: {fileID: 21300000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}
-  - AssetId:
-      m_storage: 6d14fbfb-78a0-4b9b-99f3-95e130e3ea66
-    Asset: {fileID: 21300000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
-  - AssetId:
-      m_storage: 8965520c-51eb-4aa9-b24b-cedc6216a015
-    Asset: {fileID: 21300000, guid: 788648182fdba814396e5258870a63f0, type: 3}
-  - AssetId:
-      m_storage: 6ea99f1a-bc09-4c94-81e6-0a78fe2cb282
-    Asset: {fileID: 21300000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
-  - AssetId:
-      m_storage: 703d481b-88b9-4ea2-b115-f273f9e8140d
-    Asset: {fileID: 21300000, guid: 1780007991c511c4194928e7d680db74, type: 3}
-  - AssetId:
-      m_storage: 699ecc71-412f-4b7f-9415-f3d740266056
-    Asset: {fileID: 21300000, guid: 03b731c99d54dfb4abde4d7d1b1b9199, type: 3}
-  - AssetId:
-      m_storage: c47aa651-9ded-4fd9-8f5d-b7139c3c715c
-    Asset: {fileID: 21300000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
-  - AssetId:
-      m_storage: e1117981-e53e-406a-8407-db404572dfe1
+      guid:
+        m_storage: 01b6830a-93a3-6904-ab13-9325358f2d35
+      fileIdentifier: 21300000
     Asset: {fileID: 21300000, guid: 01b6830a93a36904ab139325358f2d35, type: 3}
   - AssetId:
-      m_storage: a2d58e3c-91b9-4411-9de4-199897e7f089
-    Asset: {fileID: 21300000, guid: 3038942a8632b664795da551e3a65b25, type: 3}
+      guid:
+        m_storage: 01e02995-805e-b483-6903-80a911a657e2
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 01e02995805eb483690380a911a657e2, type: 3}
   - AssetId:
-      m_storage: cf52c4c2-72e5-4dbf-9682-8d470444ee8d
-    Asset: {fileID: 21300000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
+      guid:
+        m_storage: 03b731c9-9d54-dfb4-abde-4d7d1b1b9199
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 03b731c99d54dfb4abde4d7d1b1b9199, type: 3}
   - AssetId:
-      m_storage: 6eb7f2fc-7970-470e-97fa-a9797c50e588
-    Asset: {fileID: 21300000, guid: 2f3bf31bda2bd84439e477aac79990ca, type: 3}
+      guid:
+        m_storage: 0ac4e434-e8bf-54a4-18c7-e6ff28cdf07b
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
   - AssetId:
-      m_storage: 00490c22-55ce-486a-b6c1-f9d6da6edea2
+      guid:
+        m_storage: 0b431d73-cc83-7214-fbf6-7cab3535f975
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 0b431d73cc837214fbf67cab3535f975, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 0ea40b84-2547-d784-082e-bf2698d3f08b
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 0ea40b842547d784082ebf2698d3f08b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 1520ffe2-2e03-8294-9b34-d64a73900077
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 229c3211-a796-6124-ca2b-aa412fae0b0f
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 229c3211a7966124ca2baa412fae0b0f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 28ea40d5-0737-d3c4-7af0-18f7f3ea24ee
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 28ea40d50737d3c47af018f7f3ea24ee, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2a95b12b-f068-e064-9889-84ff0723e935
+      fileIdentifier: 21300000
     Asset: {fileID: 21300000, guid: 2a95b12bf068e064988984ff0723e935, type: 3}
   - AssetId:
-      m_storage: 90302828-a038-47f2-b58a-5a78f96877dc
-    Asset: {fileID: 21300000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
-  - AssetId:
-      m_storage: ec7c25da-b3d1-4d58-8e96-f95bf25dda23
-    Asset: {fileID: 21300000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
-  - AssetId:
-      m_storage: 96bbac50-1ece-4c5d-991f-b266bc6cf8e1
-    Asset: {fileID: 21300000, guid: 94c407cca90801e47aead1757ce0ae05, type: 3}
-  - AssetId:
-      m_storage: e6877438-495e-4613-a6fa-7611b7c7a1ec
-    Asset: {fileID: 21300000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
-  - AssetId:
-      m_storage: 38b05501-67e5-446f-aa6f-b3781f8bc2e8
-    Asset: {fileID: 21300000, guid: 417cf16dd6895c44f82149efa15170d5, type: 3}
-  - AssetId:
-      m_storage: e2159e6f-aa9e-4843-851b-b258adf88c2e
-    Asset: {fileID: 21300000, guid: 8485eaaddfc849647a3b00d6006e6bc8, type: 3}
-  - AssetId:
-      m_storage: bcb7b5a0-3f10-4868-8f2d-f5fcf983204c
-    Asset: {fileID: 21300000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
-  - AssetId:
-      m_storage: e1824c3b-a4ff-411c-a9ef-9673e9024d42
-    Asset: {fileID: 21300000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
-  - AssetId:
-      m_storage: 59d99e8b-dcdb-4b14-8bcf-809ee3ba3955
-    Asset: {fileID: 21300000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
-  - AssetId:
-      m_storage: 4179a1ee-e357-4eb3-8f38-c521825bbfa0
-    Asset: {fileID: 21300000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
-  - AssetId:
-      m_storage: b6ead579-f752-4007-b9aa-76eef1fd0972
-    Asset: {fileID: 21300000, guid: 4f391b0f78f0f294585d13e6e4ddbcc4, type: 3}
-  - AssetId:
-      m_storage: 8380703a-1adb-408d-8110-166de07a8e57
-    Asset: {fileID: 21300000, guid: b98b3e1f52d80b34a8c2a7a75d3e70ec, type: 3}
-  - AssetId:
-      m_storage: 721be5fd-9c7c-4f2b-833c-e8253fedba3a
-    Asset: {fileID: 21300000, guid: cd82213f1cb29ac40823f002b56504fa, type: 3}
-  - AssetId:
-      m_storage: 09c75909-7438-424e-b4e9-efb3e792fde4
+      guid:
+        m_storage: 2b90b3ff-0e9f-24a4-3a1f-8ffacaa12ca7
+      fileIdentifier: 21300000
     Asset: {fileID: 21300000, guid: 2b90b3ff0e9f24a43a1f8ffacaa12ca7, type: 3}
   - AssetId:
-      m_storage: 15889bff-68c9-4de2-be44-8f36022ac3ab
-    Asset: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+      guid:
+        m_storage: 2e1868a1-5829-5364-59f5-d0022d6ec0b5
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2f3bf31b-da2b-d844-39e4-77aac79990ca
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 2f3bf31bda2bd84439e477aac79990ca, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3038942a-8632-b664-795d-a551e3a65b25
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 3038942a8632b664795da551e3a65b25, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 375eed97-2162-2324-3984-8c636aab9117
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 375eed972162232439848c636aab9117, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3ba76ce0-e2c9-a7c4-5801-facdc7e24384
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3cf132d4-fa07-f4f0-cb28-83499c5c7dd0
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 417cf16d-d689-5c44-f821-49efa15170d5
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 417cf16dd6895c44f82149efa15170d5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 426a1fee-d732-8674-1995-65d08aa1abe4
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4af5db22-4464-bf34-cb8f-dc70ee470b65
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4c433abc-db28-444e-bb7b-d395ba5c76fc
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4dfd3f5d-a889-44ec-6ac5-977d676c30c6
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4f391b0f-78f0-f294-585d-13e6e4ddbcc4
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 4f391b0f78f0f294585d13e6e4ddbcc4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 599a5fd9-2bab-81a4-ab02-e52d0b1b1c60
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 61438131-b4fd-ac44-6a91-f664f1770aad
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6344c474-9a58-54a4-fb03-3def626a8547
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6588fe84-4902-0f74-488b-8b667ce2f435
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 6588fe8449020f74488b8b667ce2f435, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 68157127-a155-0704-596f-2546ea8893d9
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 68157127a1550704596f2546ea8893d9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6deea620-179c-aad4-d97d-51e0e6e03010
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 739d0ad3-b6c1-0dc4-9b8a-45caf9002249
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 78864818-2fdb-a814-396e-5258870a63f0
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 788648182fdba814396e5258870a63f0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 84643a20-fa6b-4fa7-969e-f84ad2e40992
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 84643a20fa6b4fa7969ef84ad2e40992, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8485eaad-dfc8-4964-7a3b-00d6006e6bc8
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 8485eaaddfc849647a3b00d6006e6bc8, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a0da391-9302-1fa4-cb9b-71d883d30b97
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a86432c-6c39-2234-79e7-d6b663242ae9
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8e8fc4c5-d417-b754-280c-d920d79a5e7f
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 8e8fc4c5d417b754280cd920d79a5e7f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 94c407cc-a908-01e4-7aea-d1757ce0ae05
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 94c407cca90801e47aead1757ce0ae05, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 96d001f4-572c-a3e4-485a-62e1a049524e
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 96d001f4572ca3e4485a62e1a049524e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a7d0f692-b982-a754-b8ae-2353d5e88d64
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: a7d0f692b982a754b8ae2353d5e88d64, type: 3}
+  - AssetId:
+      guid:
+        m_storage: acc34040-a66f-e417-0bc8-885268860cfe
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b2c8cdd0-abb0-99e4-3b24-fe3c1944e166
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b7c2f847-b307-3494-5a20-fd895bfd2717
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b866a23e-6fb7-94a4-5bb5-71ce249f1c93
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b98b3e1f-52d8-0b34-a8c2-a7a75d3e70ec
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: b98b3e1f52d80b34a8c2a7a75d3e70ec, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c2c00ef2-1cc4-4bcf-a096-95879e0ebecd
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: c2c00ef21cc44bcfa09695879e0ebecd, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c82628e7-a85e-39c4-181b-8f4bbc022896
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c91313de-4a57-9684-fb5a-4d33009a2497
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
+  - AssetId:
+      guid:
+        m_storage: cd82213f-1cb2-9ac4-0823-f002b56504fa
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: cd82213f1cb29ac40823f002b56504fa, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d651fc00-b471-cfe4-4834-a222e9433461
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: d651fc00b471cfe44834a222e9433461, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d6cb64fe-b90e-0314-f9c6-e885fcc3d39b
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: d6cb64feb90e0314f9c6e885fcc3d39b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d7776e47-f36f-9954-58a9-2021b99f44d5
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: d7776e47f36f995458a92021b99f44d5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d867b2e3-61e9-0944-b8b1-ee90338f4350
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e331c375-9dc6-afb4-086a-58238fc6934c
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eabaead8-25c4-fa84-6947-4a08de620d78
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ec74779a-ec7b-9eb4-aa02-bc94fe6c78c9
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: edf886be-8536-b924-8994-f01ae476fe11
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f2237692-de96-24a4-692e-4b0440c5f476
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: f2237692de9624a4692e4b0440c5f476, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f8eca3a7-11f4-842e-ba0c-52ea9885ef7f
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/TextMeshProFontAssetCache.asset
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/TextMeshProFontAssetCache.asset
@@ -14,26 +14,42 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: 7b79034a-0f7d-4880-a4c6-7e2f4fe99c2c
-    Asset: {fileID: 11400000, guid: 8f25585131267564cab5bbdafd36a94f, type: 2}
-  - AssetId:
-      m_storage: 36963a34-9dc0-4b81-92ab-610fad5189b0
-    Asset: {fileID: 11400000, guid: f137eba12ee10834cb19632437cfdb2e, type: 2}
-  - AssetId:
-      m_storage: bfc38baf-b5b5-4ffd-ab82-1cf632c24557
-    Asset: {fileID: 11400000, guid: fc8fa6e10f9c7fa4fa49a53ec702237e, type: 2}
-  - AssetId:
-      m_storage: 9ef89c69-19d3-46ab-87bd-58433eb95f6a
-    Asset: {fileID: 11400000, guid: d94d0d64ec3545b408d5621e7d27cf96, type: 2}
-  - AssetId:
-      m_storage: e7507801-9b23-4f45-b160-77f0389c6fa9
+      guid:
+        m_storage: 6a84f857-bec7-e734-5843-ae29404c57ce
+      fileIdentifier: 11400000
     Asset: {fileID: 11400000, guid: 6a84f857bec7e7345843ae29404c57ce, type: 2}
   - AssetId:
-      m_storage: b38ba3db-5d7f-41a5-b0b6-d50d337052fa
+      guid:
+        m_storage: 8f255851-3126-7564-cab5-bbdafd36a94f
+      fileIdentifier: 11400000
+    Asset: {fileID: 11400000, guid: 8f25585131267564cab5bbdafd36a94f, type: 2}
+  - AssetId:
+      guid:
+        m_storage: 8f586378-b4e1-44a9-851e-7b34d9b748ee
+      fileIdentifier: 11400000
     Asset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   - AssetId:
-      m_storage: fb1d2c62-69d2-4815-a4dd-dfbe222bacf5
+      guid:
+        m_storage: afc8299d-5d5b-bd44-0a06-16c8ecbc7217
+      fileIdentifier: 11400000
     Asset: {fileID: 11400000, guid: afc8299d5d5bbd440a0616c8ecbc7217, type: 2}
   - AssetId:
-      m_storage: 20701068-95f1-4c1b-b34b-e01c50eed681
+      guid:
+        m_storage: cf40b52f-b347-8de4-ea4a-df277e3b75ef
+      fileIdentifier: 11400000
     Asset: {fileID: 11400000, guid: cf40b52fb3478de4ea4adf277e3b75ef, type: 2}
+  - AssetId:
+      guid:
+        m_storage: d94d0d64-ec35-45b4-08d5-621e7d27cf96
+      fileIdentifier: 11400000
+    Asset: {fileID: 11400000, guid: d94d0d64ec3545b408d5621e7d27cf96, type: 2}
+  - AssetId:
+      guid:
+        m_storage: f137eba1-2ee1-0834-cb19-632437cfdb2e
+      fileIdentifier: 11400000
+    Asset: {fileID: 11400000, guid: f137eba12ee10834cb19632437cfdb2e, type: 2}
+  - AssetId:
+      guid:
+        m_storage: fc8fa6e1-0f9c-7fa4-fa49-a53ec702237e
+      fileIdentifier: 11400000
+    Asset: {fileID: 11400000, guid: fc8fa6e10f9c7fa4fa49a53ec702237e, type: 2}

--- a/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/TextureAssetCache.asset
+++ b/samples/Build2019Demo.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/TextureAssetCache.asset
@@ -14,452 +14,757 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: f8987bab-c14d-43ca-8bc6-936b6f280dc9
-    Asset: {fileID: 2800000, guid: d651fc00b471cfe44834a222e9433461, type: 3}
-  - AssetId:
-      m_storage: 11ea4653-ead6-4fb2-9985-dd4e99164624
-    Asset: {fileID: 2800000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
-  - AssetId:
-      m_storage: 8c21d24e-6196-4ba7-bdfd-3da209e9d2cf
-    Asset: {fileID: 2800000, guid: 84643a20fa6b4fa7969ef84ad2e40992, type: 3}
-  - AssetId:
-      m_storage: 31f9d6d7-c739-4771-8b54-100af61424a1
-    Asset: {fileID: 2800000, guid: 49679f302ac6408697f6b9314a38985c, type: 3}
-  - AssetId:
-      m_storage: 2168fd43-73fa-41ad-addf-d5fb0cda7170
-    Asset: {fileID: 2800000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
-  - AssetId:
-      m_storage: 9bc05f56-ddd4-4ced-b319-22b43d2784b5
-    Asset: {fileID: 2800000, guid: 0ece3980a49844bf181847eac75da121, type: 3}
-  - AssetId:
-      m_storage: 13db6bd9-ebfe-4f4f-898d-2865f616f8e9
-    Asset: {fileID: 2800000, guid: ca51b19024094d1b87f3e07edb0a75fb, type: 3}
-  - AssetId:
-      m_storage: 7c5b6a4d-78a3-4d9a-b465-da7c61cd41a0
-    Asset: {fileID: 2800000, guid: 6eccdbd0228d47ab9ac6ca58258f9112, type: 3}
-  - AssetId:
-      m_storage: d50fb9ef-d9c4-4c68-9545-e3fbf1843499
-    Asset: {fileID: 2800000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
-  - AssetId:
-      m_storage: e8d79baa-cc7f-4c28-8d62-a74863834fd4
-    Asset: {fileID: 2800000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
-  - AssetId:
-      m_storage: 2b8ef82e-26b9-4572-a2c5-8b10c1c0f9fe
-    Asset: {fileID: 2800000, guid: 0d9a36012a224080966c7b55896aa0f9, type: 3}
-  - AssetId:
-      m_storage: 5d1500fa-9c1c-485b-8ffd-3ede01537477
-    Asset: {fileID: 2800000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
-  - AssetId:
-      m_storage: 5a66a893-169d-4647-9764-a5671a539b23
-    Asset: {fileID: 2800000, guid: 18775b51e3bd42299fd30bd036ea982f, type: 3}
-  - AssetId:
-      m_storage: 58a784b3-bab1-4b04-b201-5194df5b756c
-    Asset: {fileID: 2800000, guid: b5066c514f7f02f4292cf842f3c8b75f, type: 3}
-  - AssetId:
-      m_storage: 69060529-3b23-4dca-9668-162ea48518f9
-    Asset: {fileID: 2800000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
-  - AssetId:
-      m_storage: d1080318-c449-4492-93c9-47f7bac0c221
-    Asset: {fileID: 2800000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
-  - AssetId:
-      m_storage: fd19f5fb-ea38-49fd-8179-815778c2e1cc
-    Asset: {fileID: 2800000, guid: ed47c1d1895484151b1081f5536df76c, type: 3}
-  - AssetId:
-      m_storage: 3a0e3d21-8e28-46cb-a5f4-75cf5cd7dfe7
-    Asset: {fileID: 2800000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
-  - AssetId:
-      m_storage: 34501bb2-0844-4166-91df-a9cd08c847fe
-    Asset: {fileID: 2800000, guid: 7de780622ddab5e49b73d5d7a806faf9, type: 3}
-  - AssetId:
-      m_storage: 95eb7f0d-3ae5-42ef-9dbf-9b363b7a0c64
-    Asset: {fileID: 2800000, guid: f2237692de9624a4692e4b0440c5f476, type: 3}
-  - AssetId:
-      m_storage: 60a2cae0-cacc-4904-871e-bf610e8654bb
-    Asset: {fileID: 2800000, guid: a7d0f692b982a754b8ae2353d5e88d64, type: 3}
-  - AssetId:
-      m_storage: f5c02251-c91a-43a7-bfc6-0dbb94245c89
-    Asset: {fileID: 2800000, guid: bb1b4a9241fba2042a81428e917afd5d, type: 3}
-  - AssetId:
-      m_storage: d3909a81-18e8-48f2-a2db-6cd962969988
-    Asset: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
-  - AssetId:
-      m_storage: e3b8a025-200c-497f-b57c-86c242c66952
-    Asset: {fileID: 2800000, guid: 8bc1f0e2862754e4492fa0179903ce74, type: 3}
-  - AssetId:
-      m_storage: e12c6b3d-ca83-45d8-819b-ba47e8698289
-    Asset: {fileID: 2800000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
-  - AssetId:
-      m_storage: dad5cd1e-0420-49c2-b0b1-9abfeca25e8d
-    Asset: {fileID: 2800000, guid: c2c00ef21cc44bcfa09695879e0ebecd, type: 3}
-  - AssetId:
-      m_storage: 7fb17667-b548-4468-be07-4b2ed1662bee
-    Asset: {fileID: 2800000, guid: 8e35f9234c1f48f44b660f8bae903a0f, type: 3}
-  - AssetId:
-      m_storage: 8e2442e2-2739-49d0-89e3-6bac5eb4390d
-    Asset: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
-  - AssetId:
-      m_storage: e4374b01-1ae6-4731-940c-eb44bf2eb8a9
-    Asset: {fileID: 2800000, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
-  - AssetId:
-      m_storage: 6eba63dc-8cfd-43d5-a84d-a5a9656bff52
-    Asset: {fileID: 2800000, guid: 0b431d73cc837214fbf67cab3535f975, type: 3}
-  - AssetId:
-      m_storage: 031117cc-f2de-4d97-8c5f-7ce6306b1c4e
-    Asset: {fileID: 2800000, guid: 6ace62d30f494c948b71d5594afce11d, type: 3}
-  - AssetId:
-      m_storage: 94a2ca4a-bd00-47cf-95bd-134840a3756b
-    Asset: {fileID: 2800000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
-  - AssetId:
-      m_storage: 97acf5a0-5621-4cfd-b11e-80cf8748ee2b
-    Asset: {fileID: 2800000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
-  - AssetId:
-      m_storage: 66e05aac-cc52-4960-a518-71bd5646c603
-    Asset: {fileID: 2800000, guid: 41b96614b2e6494ba995ddcd252d11ae, type: 3}
-  - AssetId:
-      m_storage: 5b571eea-4810-4c6d-a606-7af50a311e55
-    Asset: {fileID: 2800000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
-  - AssetId:
-      m_storage: e737ba9a-f498-4742-b2ac-e478803a1dd4
-    Asset: {fileID: 2800000, guid: 427e0e647801a0c49b51b9cc0b812334, type: 3}
-  - AssetId:
-      m_storage: f785d8b2-39f0-4cd5-80b7-e528a04f976a
-    Asset: {fileID: 2800000, guid: f00430742d7974401a53e2867631536b, type: 3}
-  - AssetId:
-      m_storage: 3d99bf2a-80c1-4750-9d8f-b12dbc689dcc
-    Asset: {fileID: 2800000, guid: ac20e3743f379204ca53e379eb2fb59e, type: 3}
-  - AssetId:
-      m_storage: 566d49df-8e98-4c33-ae5e-2cdca6de72de
-    Asset: {fileID: 2800000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
-  - AssetId:
-      m_storage: 34dfadc9-5d6f-4f7b-aaa3-5f8a433018b5
-    Asset: {fileID: 2800000, guid: 0ea40b842547d784082ebf2698d3f08b, type: 3}
-  - AssetId:
-      m_storage: 7be757e9-850f-40cd-afc5-c8488933d9d0
-    Asset: {fileID: 2800000, guid: 6588fe8449020f74488b8b667ce2f435, type: 3}
-  - AssetId:
-      m_storage: 53477e3e-ecc6-4b3b-ac0e-7e59c21b4ce2
-    Asset: {fileID: 2800000, guid: d0b89fa47caf144e49c3ef040cbda163, type: 3}
-  - AssetId:
-      m_storage: f8987328-dd9e-4b73-8dd0-7430f5b0e6c2
-    Asset: {fileID: 2800000, guid: 48d034c499ee4697af9dd6e327110249, type: 3}
-  - AssetId:
-      m_storage: a611e7d7-c9ab-4e35-abfa-dabcc45e4a2c
-    Asset: {fileID: 2800000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
-  - AssetId:
-      m_storage: b7851a09-7b4a-4341-8ff8-d71fbee7940a
-    Asset: {fileID: 2800000, guid: 96d001f4572ca3e4485a62e1a049524e, type: 3}
-  - AssetId:
-      m_storage: 186cfc77-2aa5-4783-917d-a43fbc74c258
-    Asset: {fileID: 2800000, guid: 5594253527100df43a615c542bf0aaa7, type: 3}
-  - AssetId:
-      m_storage: 35487f80-7f86-4d2c-9449-b62e3d93de00
-    Asset: {fileID: 2800000, guid: e41f0635be0504698a181d1e71b88691, type: 3}
-  - AssetId:
-      m_storage: ff839918-8fc6-4bc7-9e4c-4909482283db
-    Asset: {fileID: 2800000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
-  - AssetId:
-      m_storage: 151000d8-65ea-4c49-8714-04864f2c6a17
-    Asset: {fileID: 2800000, guid: bd30f98596e69f7469fda20a47760dd1, type: 3}
-  - AssetId:
-      m_storage: 20d7561a-e8b9-460e-be44-693d7b5b06de
-    Asset: {fileID: 2800000, guid: 01e02995805eb483690380a911a657e2, type: 3}
-  - AssetId:
-      m_storage: 3e1e8aa1-bf92-46b2-a7ab-0b953c4a6a86
-    Asset: {fileID: 2800000, guid: 8e8fc4c5d417b754280cd920d79a5e7f, type: 3}
-  - AssetId:
-      m_storage: f2d1869e-3cf4-4a00-a033-40a0a09a03d3
-    Asset: {fileID: 2800000, guid: 691475c57a824010be0c6f474caeb7e1, type: 3}
-  - AssetId:
-      m_storage: fed985bc-ef9e-4db9-b0e2-3ac421c972f9
-    Asset: {fileID: 2800000, guid: bb353ac508e7c4201a260e00d69e1daf, type: 3}
-  - AssetId:
-      m_storage: 8da343b0-184a-429f-9bfa-0232e41f0953
-    Asset: {fileID: 2800000, guid: 28ea40d50737d3c47af018f7f3ea24ee, type: 3}
-  - AssetId:
-      m_storage: e6ee03fc-8490-4327-90e1-21b78cb61926
-    Asset: {fileID: 2800000, guid: 8847dee5697a04f749b9ec611224ac4d, type: 3}
-  - AssetId:
-      m_storage: 2c6da993-3556-4eac-a529-2f246e087a87
-    Asset: {fileID: 2800000, guid: 10bf81265ad87424d946598c575f45a0, type: 3}
-  - AssetId:
-      m_storage: f49fb46b-9c75-4880-8173-ef21785b3baf
-    Asset: {fileID: 2800000, guid: 81ed8c76d2bc4a4c95d092c98af4e58f, type: 3}
-  - AssetId:
-      m_storage: cee79ff4-da72-4a40-b5ff-96e72783e9dc
-    Asset: {fileID: 2800000, guid: 98e3b4b60df348344985cb363d5778fc, type: 3}
-  - AssetId:
-      m_storage: c815836b-7798-4361-91a8-9fc42498141d
-    Asset: {fileID: 2800000, guid: 64b9fad609434c489c32b1cdf2004a1c, type: 3}
-  - AssetId:
-      m_storage: d47c5d2f-b07a-40c1-ac2e-2acbbb3272ce
-    Asset: {fileID: 2800000, guid: 68157127a1550704596f2546ea8893d9, type: 3}
-  - AssetId:
-      m_storage: 525bbd4a-18f5-4392-adbf-5907e77c3ece
-    Asset: {fileID: 2800000, guid: 35ff0937876540d3bd4b6a941df62a92, type: 3}
-  - AssetId:
-      m_storage: 51765a6f-2406-47b9-a04c-a47ad43f272c
-    Asset: {fileID: 2800000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
-  - AssetId:
-      m_storage: 8a7aba0c-9e87-4297-ac51-c5edc128fae4
-    Asset: {fileID: 2800000, guid: d7776e47f36f995458a92021b99f44d5, type: 3}
-  - AssetId:
-      m_storage: 99d7daa0-be9f-48ff-9a25-77e5e6c3a01e
-    Asset: {fileID: 2800000, guid: eaf7f6872bf544df39a814d587c5a63e, type: 3}
-  - AssetId:
-      m_storage: 7cd61aa0-b3ba-4449-80b6-db345943560b
-    Asset: {fileID: 2800000, guid: 375eed972162232439848c636aab9117, type: 3}
-  - AssetId:
-      m_storage: a6ca49ba-21e1-4a0f-b6a4-f961a974e592
-    Asset: {fileID: 2800000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}
-  - AssetId:
-      m_storage: 359d75aa-df7e-4522-b1df-1dce7d6d26be
-    Asset: {fileID: 2800000, guid: 466b28a7abdd4f2fb56a1b9f929d7aaa, type: 3}
-  - AssetId:
-      m_storage: 55af9162-2acc-47bd-a482-bbce242cadc0
-    Asset: {fileID: 2800000, guid: 3ee40aa79cd242a5b53b0b0ca4f13f0f, type: 3}
-  - AssetId:
-      m_storage: d94ff1a4-ff65-40d2-bc0b-4c186e9ac887
-    Asset: {fileID: 2800000, guid: fbd83ab71f75243d1be6b4fe8d3f77ce, type: 3}
-  - AssetId:
-      m_storage: 41a371a9-3c7f-4375-88e3-5c23a506cabe
-    Asset: {fileID: 2800000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
-  - AssetId:
-      m_storage: f067c9d6-baf3-407d-88eb-78e24db92fce
-    Asset: {fileID: 2800000, guid: ed706df75463c46c6b5036d99ca2e8bb, type: 3}
-  - AssetId:
-      m_storage: c41cd252-9855-4c25-8913-7da35b313aa7
-    Asset: {fileID: 2800000, guid: 788648182fdba814396e5258870a63f0, type: 3}
-  - AssetId:
-      m_storage: 4e8ef070-e5a0-4710-ba07-2219da345dca
-    Asset: {fileID: 2800000, guid: ee148e281f3c41c5b4ff5f8a5afe5a6c, type: 3}
-  - AssetId:
-      m_storage: 002e550e-4389-4b49-a55a-53e7b2ff7a1d
-    Asset: {fileID: 2800000, guid: d74cdc58c5d172a469ea5ca987eb17f6, type: 3}
-  - AssetId:
-      m_storage: 813a5e28-4388-48b2-9c29-228ee850aac1
-    Asset: {fileID: 2800000, guid: ed041e68439749a69d0efa0e3d896c2e, type: 3}
-  - AssetId:
-      m_storage: 1c595688-5352-4ba3-bded-04ac702c0c8c
-    Asset: {fileID: 2800000, guid: 291b0378706ecbe45b8dad41f9b226c2, type: 3}
-  - AssetId:
-      m_storage: 37834605-d41f-40a6-b9bb-6022c97aa569
-    Asset: {fileID: 2800000, guid: a25aa578421df4048adb5146b2f8f9c1, type: 3}
-  - AssetId:
-      m_storage: 254d0cca-3eea-4385-906f-cbd7c05bb72d
-    Asset: {fileID: 2800000, guid: 12736c98af174f91827a26b66d2b01b9, type: 3}
-  - AssetId:
-      m_storage: 2dd8f8ba-1c9b-4490-9a8a-bd1f85567ea4
-    Asset: {fileID: 2800000, guid: c2f7f6a88b4c4f20a53deb72f3d9144c, type: 3}
-  - AssetId:
-      m_storage: 0c0269d3-0e5d-460b-9593-5f848f1448b2
-    Asset: {fileID: 2800000, guid: 4c4008a8f878545798c76e17b4faf755, type: 3}
-  - AssetId:
-      m_storage: 354be5b1-02e4-41ee-a2e2-032f3d833260
-    Asset: {fileID: 2800000, guid: 2e6ca3c8f061c498999fc725a892986c, type: 3}
-  - AssetId:
-      m_storage: d6da0478-2cce-446c-838a-59caddf5e29f
-    Asset: {fileID: 2800000, guid: 8d0274d8bc6a17844a08b493920d9491, type: 3}
-  - AssetId:
-      m_storage: 8556cf29-000e-4a6c-9fb2-a689c5f14f3b
-    Asset: {fileID: 2800000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
-  - AssetId:
-      m_storage: 12266cb0-bb77-4c90-8858-0fb6c05213e8
-    Asset: {fileID: 2800000, guid: 6de548e8ec86c4547969a0148a6172c7, type: 3}
-  - AssetId:
-      m_storage: a0319c58-2357-414a-81d1-2405cee210aa
-    Asset: {fileID: 2800000, guid: 3d652c19bde24a29871839929991b0be, type: 3}
-  - AssetId:
-      m_storage: b5b49d7e-3dda-4211-aa63-df3cfb65c822
-    Asset: {fileID: 2800000, guid: 1780007991c511c4194928e7d680db74, type: 3}
-  - AssetId:
-      m_storage: f43df57d-39fb-4f49-8705-6f8b69ea9924
-    Asset: {fileID: 2800000, guid: 5e7c9ab97e5884e4eaa5967e9024f39d, type: 3}
-  - AssetId:
-      m_storage: f6e1f3fb-0606-4b68-8d13-9f43d457e999
-    Asset: {fileID: 2800000, guid: 03b731c99d54dfb4abde4d7d1b1b9199, type: 3}
-  - AssetId:
-      m_storage: 0c273c97-5973-4120-98c8-d33212ab413c
-    Asset: {fileID: 2800000, guid: 066619c9c9c84f89acb1b48c11a7efe2, type: 3}
-  - AssetId:
-      m_storage: 9fa39540-0e45-4748-a446-ab57de9060dd
-    Asset: {fileID: 2800000, guid: bb42b2d967d6427983c901a4ffc8ecd9, type: 3}
-  - AssetId:
-      m_storage: fee22f79-359c-42f4-a018-5a06d72174da
-    Asset: {fileID: 2800000, guid: d31bc7d943a7b954cb8a02a129e447f8, type: 3}
-  - AssetId:
-      m_storage: 9356d52d-884f-41ce-9ee6-0bfe96d92393
-    Asset: {fileID: 2800000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
-  - AssetId:
-      m_storage: 588d31d9-5a8f-4cbd-a763-f38d5016b16c
-    Asset: {fileID: 2800000, guid: eeb590e919d35479097aed649f2c5f67, type: 3}
-  - AssetId:
-      m_storage: db790025-e226-41cc-b9d2-07a6304236d0
-    Asset: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
-  - AssetId:
-      m_storage: bb610a5b-8baf-4c77-8624-ddc086a4aae0
+      guid:
+        m_storage: 01b6830a-93a3-6904-ab13-9325358f2d35
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 01b6830a93a36904ab139325358f2d35, type: 3}
   - AssetId:
-      m_storage: 0809d96c-5008-4a66-89e9-47cfcabea01b
-    Asset: {fileID: 2800000, guid: fa6bd40a216346b783a4cce741d277a5, type: 3}
+      guid:
+        m_storage: 01e02995-805e-b483-6903-80a911a657e2
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 01e02995805eb483690380a911a657e2, type: 3}
   - AssetId:
-      m_storage: ccecd912-db22-47bd-9939-a60f7090826d
-    Asset: {fileID: 2800000, guid: 3038942a8632b664795da551e3a65b25, type: 3}
-  - AssetId:
-      m_storage: df6672c3-6027-46b4-b3eb-ae34bcd948e9
-    Asset: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
-  - AssetId:
-      m_storage: 6837c2e0-dc35-4fc1-a8ca-7984f8c053bd
-    Asset: {fileID: 2800000, guid: a7ec9e7ad8b847b7ae4510af83c5d868, type: 3}
-  - AssetId:
-      m_storage: 6611fdcf-084a-450f-a035-2a9b9212a03c
-    Asset: {fileID: 2800000, guid: 342a0f8aca7f4f0691338912faec0494, type: 3}
-  - AssetId:
-      m_storage: af43196b-efea-46e0-b5ab-197093d84790
-    Asset: {fileID: 2800000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
-  - AssetId:
-      m_storage: 23cb0df9-d2be-49ac-a50c-ebf704a6b919
-    Asset: {fileID: 2800000, guid: c76700ea0062413d9f69409b4e9e151b, type: 3}
-  - AssetId:
-      m_storage: f163e982-70e9-44e0-b988-ea9609f7a5ce
-    Asset: {fileID: 2800000, guid: 2f3bf31bda2bd84439e477aac79990ca, type: 3}
-  - AssetId:
-      m_storage: 8aab9c12-4bff-4ccd-8352-f5c22ce12103
-    Asset: {fileID: 2800000, guid: 0771cd1b5e4131e45afe250cd1713737, type: 3}
-  - AssetId:
-      m_storage: 9b580747-1804-46e4-845d-9a5ff4c7aed0
-    Asset: {fileID: 2800000, guid: 2a95b12bf068e064988984ff0723e935, type: 3}
-  - AssetId:
-      m_storage: cc3bd791-a6ce-4303-892b-41da3a5b7b62
-    Asset: {fileID: 2800000, guid: e05ace3bd15740cda0bad60d89092a5b, type: 3}
-  - AssetId:
-      m_storage: 5ae71f04-23a7-4c24-a7b7-e3a6e9768686
-    Asset: {fileID: 2800000, guid: 0bee624b4074e5445929e56287795085, type: 3}
-  - AssetId:
-      m_storage: bda70ae6-1ba0-4ae8-8d9c-1a95172468eb
-    Asset: {fileID: 2800000, guid: 8bc445bb79654bf496c92d0407840a92, type: 3}
-  - AssetId:
-      m_storage: c9d35c08-88a5-4146-9d36-fc96f2b3bc64
-    Asset: {fileID: 2800000, guid: 585b70cb75dd43efbfead809c30a1731, type: 3}
-  - AssetId:
-      m_storage: 0d704708-0d45-4ff6-9ca8-c181dde99c33
-    Asset: {fileID: 2800000, guid: 526ca60c7581842aaa0b7d34bc14f740, type: 3}
-  - AssetId:
-      m_storage: f3a30a43-0804-48c6-af2b-107e8913913a
-    Asset: {fileID: 2800000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
-  - AssetId:
-      m_storage: 8cdff7bf-3362-4618-8f0f-221a5c031691
-    Asset: {fileID: 2800000, guid: 9288066c33474b94b6ee5465f4df1cc0, type: 3}
-  - AssetId:
-      m_storage: 66926a8a-882d-429f-b080-6e6c05ae5a68
-    Asset: {fileID: 2800000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
-  - AssetId:
-      m_storage: 73efbb7d-cb9d-47dc-af04-dd126a2693ff
-    Asset: {fileID: 2800000, guid: 94c407cca90801e47aead1757ce0ae05, type: 3}
-  - AssetId:
-      m_storage: 2d2412dc-41a2-43b0-8399-b7f11bf5289a
-    Asset: {fileID: 2800000, guid: 86609bdc7f4c43d42991f96373fb8081, type: 3}
-  - AssetId:
-      m_storage: 90ee9f24-a1a9-43f7-8910-a01f8aa5b4dc
-    Asset: {fileID: 2800000, guid: 19436f0d867684b8e8c9e9486c16f3b6, type: 3}
-  - AssetId:
-      m_storage: 9938f62f-a853-4d5e-b322-4ac249521bf7
-    Asset: {fileID: 2800000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
-  - AssetId:
-      m_storage: 7f32188e-60be-4996-9ad5-dfe0561f4dab
-    Asset: {fileID: 2800000, guid: 417cf16dd6895c44f82149efa15170d5, type: 3}
-  - AssetId:
-      m_storage: ad866aff-8363-4640-a089-9fa13a00b267
+      guid:
+        m_storage: 0368159d-8401-d4bf-f81b-9c85d4730446
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 0368159d8401d4bff81b9c85d4730446, type: 3}
   - AssetId:
-      m_storage: 83292d79-f746-4b02-a810-26efa859c836
-    Asset: {fileID: 2800000, guid: 8485eaaddfc849647a3b00d6006e6bc8, type: 3}
+      guid:
+        m_storage: 03b731c9-9d54-dfb4-abde-4d7d1b1b9199
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 03b731c99d54dfb4abde4d7d1b1b9199, type: 3}
   - AssetId:
-      m_storage: 3480c487-f8b4-4ab8-a035-1e8e6e32a934
-    Asset: {fileID: 2800000, guid: bb0617bde6c534c3abc7c6bce648c578, type: 3}
+      guid:
+        m_storage: 066619c9-c9c8-4f89-acb1-b48c11a7efe2
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 066619c9c9c84f89acb1b48c11a7efe2, type: 3}
   - AssetId:
-      m_storage: a74181ad-87f8-4fd4-8f61-e1f26ecd26a5
-    Asset: {fileID: 2800000, guid: a54eac0e085a44468963fa57f209470d, type: 3}
+      guid:
+        m_storage: 0771cd1b-5e41-31e4-5afe-250cd1713737
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0771cd1b5e4131e45afe250cd1713737, type: 3}
   - AssetId:
-      m_storage: 76f2e48d-f5a7-4407-926b-421914b8206d
-    Asset: {fileID: 2800000, guid: 7d4ad91e1389b894684e74a0b97d25e7, type: 3}
+      guid:
+        m_storage: 0ac4e434-e8bf-54a4-18c7-e6ff28cdf07b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
   - AssetId:
-      m_storage: 35f0e15f-ee3e-4912-9741-d303cde0e6e2
-    Asset: {fileID: 2800000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
+      guid:
+        m_storage: 0b431d73-cc83-7214-fbf6-7cab3535f975
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0b431d73cc837214fbf67cab3535f975, type: 3}
   - AssetId:
-      m_storage: 2c5cf2a3-de84-4dd5-b97f-0f2692864b45
-    Asset: {fileID: 2800000, guid: fb74736e21b114c6185e5536fb3f1c8d, type: 3}
+      guid:
+        m_storage: 0bee624b-4074-e544-5929-e56287795085
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0bee624b4074e5445929e56287795085, type: 3}
   - AssetId:
-      m_storage: 6d97bbbf-0948-4133-a1aa-b2123817f2d5
-    Asset: {fileID: 2800000, guid: 5ced9c7e98be2e941a88b5d0a16b2a3b, type: 3}
+      guid:
+        m_storage: 0d9a3601-2a22-4080-966c-7b55896aa0f9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0d9a36012a224080966c7b55896aa0f9, type: 3}
   - AssetId:
-      m_storage: c0a18d68-c1f0-49dd-ba07-e9f39daa72f0
-    Asset: {fileID: 2800000, guid: b44193be762b4e3aa8703213d677338d, type: 3}
+      guid:
+        m_storage: 0ea40b84-2547-d784-082e-bf2698d3f08b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0ea40b842547d784082ebf2698d3f08b, type: 3}
   - AssetId:
-      m_storage: 6dea7ad2-61da-4989-aaca-8debe4fffacf
-    Asset: {fileID: 2800000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
+      guid:
+        m_storage: 0ece3980-a498-44bf-1818-47eac75da121
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0ece3980a49844bf181847eac75da121, type: 3}
   - AssetId:
-      m_storage: 2bfdba53-2c56-45bf-be21-9dd9ad213102
+      guid:
+        m_storage: 10bf8126-5ad8-7424-d946-598c575f45a0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 10bf81265ad87424d946598c575f45a0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 12736c98-af17-4f91-827a-26b66d2b01b9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 12736c98af174f91827a26b66d2b01b9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 1520ffe2-2e03-8294-9b34-d64a73900077
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 18775b51-e3bd-4229-9fd3-0bd036ea982f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 18775b51e3bd42299fd30bd036ea982f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 19436f0d-8676-84b8-e8c9-e9486c16f3b6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 19436f0d867684b8e8c9e9486c16f3b6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 1b32bcce-201b-4494-ea88-48326290c5d5
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 1b32bcce201b4494ea8848326290c5d5, type: 3}
   - AssetId:
-      m_storage: 23c7de26-9c8a-440f-bdf4-2831581a4d62
-    Asset: {fileID: 2800000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
-  - AssetId:
-      m_storage: a30a468e-176c-4aa8-bea2-fccf9eb18ad0
-    Asset: {fileID: 2800000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
-  - AssetId:
-      m_storage: 4bb39dbd-a5ed-4ac0-966a-abb447faba25
-    Asset: {fileID: 2800000, guid: 4f391b0f78f0f294585d13e6e4ddbcc4, type: 3}
-  - AssetId:
-      m_storage: d8ff3ba1-1218-41e6-97bd-450740225c5a
-    Asset: {fileID: 2800000, guid: 2fd6421f253b4ef1a19526541f9ffc0c, type: 3}
-  - AssetId:
-      m_storage: 08553eb1-d728-440d-a608-002638e82435
-    Asset: {fileID: 2800000, guid: b98b3e1f52d80b34a8c2a7a75d3e70ec, type: 3}
-  - AssetId:
-      m_storage: d1ff32ca-8a9d-4439-9cd4-114976bec3b6
-    Asset: {fileID: 2800000, guid: cd82213f1cb29ac40823f002b56504fa, type: 3}
-  - AssetId:
-      m_storage: 14167a19-4fe7-4154-b545-8e142d4e3b63
-    Asset: {fileID: 2800000, guid: 92027f7f8cfc4feaa477da0dc38d3d46, type: 3}
-  - AssetId:
-      m_storage: 5f4d9338-c2d5-4e0b-8f49-70b9c064e534
-    Asset: {fileID: 2800000, guid: 4494cfaf424cdde49895b91e2b559258, type: 3}
-  - AssetId:
-      m_storage: 85e915fc-103c-4168-b99f-0a6f4991c1d8
-    Asset: {fileID: 2800000, guid: bcdf3dcffa0c744c9adf933757702ab6, type: 3}
-  - AssetId:
-      m_storage: 89f9752a-315e-40fb-9c98-879617979487
-    Asset: {fileID: 2800000, guid: a3a54cefff9e4d9c82dcd401480a8033, type: 3}
-  - AssetId:
-      m_storage: 1ed2eb27-9e84-4919-b52f-df37d52b5c1f
-    Asset: {fileID: 2800000, guid: 2b90b3ff0e9f24a43a1f8ffacaa12ca7, type: 3}
-  - AssetId:
-      m_storage: f98e1d8a-6ea2-44a0-8277-9ee723fe524a
-    Asset: {fileID: 2800000, guid: 474f3f21b48daea4f8617806305769ff, type: 3}
-  - AssetId:
-      m_storage: ba528a06-56e0-48ce-9be4-3354cf6611ea
-    Asset: {fileID: 2800000, guid: fda1fd92664e84e438ea8e4e243c3ddc, type: 3}
-  - AssetId:
-      m_storage: 8bc5db00-4378-41a1-8e8f-799c77f1a8f4
-    Asset: {fileID: 2800000, guid: 230b98155638e544892c123d8d674737, type: 3}
-  - AssetId:
-      m_storage: 88b653f5-feee-4cbd-9c60-403318302d75
-    Asset: {fileID: 2800000, guid: c079cf55f13c1dc4db7d09053a51a40d, type: 3}
-  - AssetId:
-      m_storage: 8423e3c1-272b-4cd2-8098-db5f0a69335c
+      guid:
+        m_storage: 1bfd4df7-e86b-1864-0b9f-a1af5713bfb9
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 1bfd4df7e86b18640b9fa1af5713bfb9, type: 3}
   - AssetId:
-      m_storage: ecab377c-c395-4658-bb28-c0c2c4d46444
-    Asset: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+      guid:
+        m_storage: 229c3211-a796-6124-ca2b-aa412fae0b0f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 229c3211a7966124ca2baa412fae0b0f, type: 3}
   - AssetId:
-      m_storage: 235dc1b8-d61f-4683-8651-d39173a74464
-    Asset: {fileID: 2800000, guid: a5d8e80a54741dc459e4f116e1d477f2, type: 3}
+      guid:
+        m_storage: 230b9815-5638-e544-892c-123d8d674737
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 230b98155638e544892c123d8d674737, type: 3}
   - AssetId:
-      m_storage: 21604f4d-3e7b-473b-b99e-a57ebe84556f
-    Asset: {fileID: 2800000, guid: 41375d8b68a146c4db0400cc632ed4e0, type: 3}
+      guid:
+        m_storage: 28ea40d5-0737-d3c4-7af0-18f7f3ea24ee
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 28ea40d50737d3c47af018f7f3ea24ee, type: 3}
   - AssetId:
-      m_storage: ebe2caaa-698f-420c-ad82-806f1b11620d
+      guid:
+        m_storage: 291b0378-706e-cbe4-5b8d-ad41f9b226c2
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 291b0378706ecbe45b8dad41f9b226c2, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2a95b12b-f068-e064-9889-84ff0723e935
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2a95b12bf068e064988984ff0723e935, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2b90b3ff-0e9f-24a4-3a1f-8ffacaa12ca7
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2b90b3ff0e9f24a43a1f8ffacaa12ca7, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2e1868a1-5829-5364-59f5-d0022d6ec0b5
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2e6ca3c8-f061-c498-999f-c725a892986c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2e6ca3c8f061c498999fc725a892986c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2f3bf31b-da2b-d844-39e4-77aac79990ca
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2f3bf31bda2bd84439e477aac79990ca, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2fd6421f-253b-4ef1-a195-26541f9ffc0c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2fd6421f253b4ef1a19526541f9ffc0c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3038942a-8632-b664-795d-a551e3a65b25
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3038942a8632b664795da551e3a65b25, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 342a0f8a-ca7f-4f06-9133-8912faec0494
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 342a0f8aca7f4f0691338912faec0494, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 35ff0937-8765-40d3-bd4b-6a941df62a92
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 35ff0937876540d3bd4b6a941df62a92, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 375eed97-2162-2324-3984-8c636aab9117
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 375eed972162232439848c636aab9117, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3afb597c-bd6e-c444-39ea-7b8ce92d957a
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 3afb597cbd6ec44439ea7b8ce92d957a, type: 3}
   - AssetId:
-      m_storage: e21bc724-2bf1-4cb7-842c-a67ca768dfe5
+      guid:
+        m_storage: 3b748943-b2ee-497c-b401-b923729b41c5
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3ba76ce0-e2c9-a7c4-5801-facdc7e24384
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3cf132d4-fa07-f4f0-cb28-83499c5c7dd0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3d652c19-bde2-4a29-8718-39929991b0be
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3d652c19bde24a29871839929991b0be, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3ee40aa7-9cd2-42a5-b53b-0b0ca4f13f0f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3ee40aa79cd242a5b53b0b0ca4f13f0f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 41375d8b-68a1-46c4-db04-00cc632ed4e0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 41375d8b68a146c4db0400cc632ed4e0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 417cf16d-d689-5c44-f821-49efa15170d5
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 417cf16dd6895c44f82149efa15170d5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 41b96614-b2e6-494b-a995-ddcd252d11ae
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 41b96614b2e6494ba995ddcd252d11ae, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 426a1fee-d732-8674-1995-65d08aa1abe4
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 427e0e64-7801-a0c4-9b51-b9cc0b812334
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 427e0e647801a0c49b51b9cc0b812334, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4494cfaf-424c-dde4-9895-b91e2b559258
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4494cfaf424cdde49895b91e2b559258, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 466b28a7-abdd-4f2f-b56a-1b9f929d7aaa
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 466b28a7abdd4f2fb56a1b9f929d7aaa, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 474f3f21-b48d-aea4-f861-7806305769ff
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 474f3f21b48daea4f8617806305769ff, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 48d034c4-99ee-4697-af9d-d6e327110249
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 48d034c499ee4697af9dd6e327110249, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 49679f30-2ac6-4086-97f6-b9314a38985c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 49679f302ac6408697f6b9314a38985c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4af5db22-4464-bf34-cb8f-dc70ee470b65
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4c4008a8-f878-5457-98c7-6e17b4faf755
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4c4008a8f878545798c76e17b4faf755, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4c433abc-db28-444e-bb7b-d395ba5c76fc
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4dfd3f5d-a889-44ec-6ac5-977d676c30c6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4f391b0f-78f0-f294-585d-13e6e4ddbcc4
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4f391b0f78f0f294585d13e6e4ddbcc4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4f9f54f9-4784-4122-8dea-18a2c828cfc6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 526ca60c-7581-842a-aa0b-7d34bc14f740
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 526ca60c7581842aaa0b7d34bc14f740, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 55942535-2710-0df4-3a61-5c542bf0aaa7
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 5594253527100df43a615c542bf0aaa7, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 585b70cb-75dd-43ef-bfea-d809c30a1731
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 585b70cb75dd43efbfead809c30a1731, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 599a5fd9-2bab-81a4-ab02-e52d0b1b1c60
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 5ced9c7e-98be-2e94-1a88-b5d0a16b2a3b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 5ced9c7e98be2e941a88b5d0a16b2a3b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 5e7c9ab9-7e58-84e4-eaa5-967e9024f39d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 5e7c9ab97e5884e4eaa5967e9024f39d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 61438131-b4fd-ac44-6a91-f664f1770aad
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6344c474-9a58-54a4-fb03-3def626a8547
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 64b9fad6-0943-4c48-9c32-b1cdf2004a1c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 64b9fad609434c489c32b1cdf2004a1c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6588fe84-4902-0f74-488b-8b667ce2f435
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6588fe8449020f74488b8b667ce2f435, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6752387e-e218-1ee4-fbef-5cc74691b6ac
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 6752387ee2181ee4fbef5cc74691b6ac, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 68157127-a155-0704-596f-2546ea8893d9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 68157127a1550704596f2546ea8893d9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 691475c5-7a82-4010-be0c-6f474caeb7e1
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 691475c57a824010be0c6f474caeb7e1, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6ace62d3-0f49-4c94-8b71-d5594afce11d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6ace62d30f494c948b71d5594afce11d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6de548e8-ec86-c454-7969-a0148a6172c7
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6de548e8ec86c4547969a0148a6172c7, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6deea620-179c-aad4-d97d-51e0e6e03010
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6eccdbd0-228d-47ab-9ac6-ca58258f9112
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6eccdbd0228d47ab9ac6ca58258f9112, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 731058d9-08be-6754-4b92-b0341f29d906
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 739d0ad3-b6c1-0dc4-9b8a-45caf9002249
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 78864818-2fdb-a814-396e-5258870a63f0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 788648182fdba814396e5258870a63f0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 7d4ad91e-1389-b894-684e-74a0b97d25e7
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 7d4ad91e1389b894684e74a0b97d25e7, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 7de78062-2dda-b5e4-9b73-d5d7a806faf9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 7de780622ddab5e49b73d5d7a806faf9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 81ed8c76-d2bc-4a4c-95d0-92c98af4e58f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 81ed8c76d2bc4a4c95d092c98af4e58f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 84643a20-fa6b-4fa7-969e-f84ad2e40992
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 84643a20fa6b4fa7969ef84ad2e40992, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8485eaad-dfc8-4964-7a3b-00d6006e6bc8
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8485eaaddfc849647a3b00d6006e6bc8, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 86609bdc-7f4c-43d4-2991-f96373fb8081
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 86609bdc7f4c43d42991f96373fb8081, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8847dee5-697a-04f7-49b9-ec611224ac4d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8847dee5697a04f749b9ec611224ac4d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a0da391-9302-1fa4-cb9b-71d883d30b97
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a86432c-6c39-2234-79e7-d6b663242ae9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8bc1f0e2-8627-54e4-492f-a0179903ce74
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8bc1f0e2862754e4492fa0179903ce74, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8bc445bb-7965-4bf4-96c9-2d0407840a92
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8bc445bb79654bf496c92d0407840a92, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8d0274d8-bc6a-1784-4a08-b493920d9491
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8d0274d8bc6a17844a08b493920d9491, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8e35f923-4c1f-48f4-4b66-0f8bae903a0f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8e35f9234c1f48f44b660f8bae903a0f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8e8fc4c5-d417-b754-280c-d920d79a5e7f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8e8fc4c5d417b754280cd920d79a5e7f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 92027f7f-8cfc-4fea-a477-da0dc38d3d46
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 92027f7f8cfc4feaa477da0dc38d3d46, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 9288066c-3347-4b94-b6ee-5465f4df1cc0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 9288066c33474b94b6ee5465f4df1cc0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 93d49a6a-e68a-4f6c-a0fe-a653caaa74fc
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 94c407cc-a908-01e4-7aea-d1757ce0ae05
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 94c407cca90801e47aead1757ce0ae05, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 961230b2-9c29-4bb7-8005-4c5d02eb6180
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 96d001f4-572c-a3e4-485a-62e1a049524e
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 96d001f4572ca3e4485a62e1a049524e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 98e3b4b6-0df3-4834-4985-cb363d5778fc
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 98e3b4b60df348344985cb363d5778fc, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a25aa578-421d-f404-8adb-5146b2f8f9c1
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a25aa578421df4048adb5146b2f8f9c1, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a3a54cef-ff9e-4d9c-82dc-d401480a8033
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a3a54cefff9e4d9c82dcd401480a8033, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a54eac0e-085a-4446-8963-fa57f209470d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a54eac0e085a44468963fa57f209470d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a5d8e80a-5474-1dc4-59e4-f116e1d477f2
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a5d8e80a54741dc459e4f116e1d477f2, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a7d0f692-b982-a754-b8ae-2353d5e88d64
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a7d0f692b982a754b8ae2353d5e88d64, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a7ec9e7a-d8b8-47b7-ae45-10af83c5d868
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a7ec9e7ad8b847b7ae4510af83c5d868, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ac20e374-3f37-9204-ca53-e379eb2fb59e
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ac20e3743f379204ca53e379eb2fb59e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: acc34040-a66f-e417-0bc8-885268860cfe
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b2c8cdd0-abb0-99e4-3b24-fe3c1944e166
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b44193be-762b-4e3a-a870-3213d677338d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b44193be762b4e3aa8703213d677338d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b5066c51-4f7f-02f4-292c-f842f3c8b75f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b5066c514f7f02f4292cf842f3c8b75f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b7c2f847-b307-3494-5a20-fd895bfd2717
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b866a23e-6fb7-94a4-5bb5-71ce249f1c93
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b98b3e1f-52d8-0b34-a8c2-a7a75d3e70ec
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b98b3e1f52d80b34a8c2a7a75d3e70ec, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bb0617bd-e6c5-34c3-abc7-c6bce648c578
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bb0617bde6c534c3abc7c6bce648c578, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bb1b4a92-41fb-a204-2a81-428e917afd5d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bb1b4a9241fba2042a81428e917afd5d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bb353ac5-08e7-c420-1a26-0e00d69e1daf
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bb353ac508e7c4201a260e00d69e1daf, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bb42b2d9-67d6-4279-83c9-01a4ffc8ecd9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bb42b2d967d6427983c901a4ffc8ecd9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bcdf3dcf-fa0c-744c-9adf-933757702ab6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bcdf3dcffa0c744c9adf933757702ab6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bd30f985-96e6-9f74-69fd-a20a47760dd1
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bd30f98596e69f7469fda20a47760dd1, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c079cf55-f13c-1dc4-db7d-09053a51a40d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c079cf55f13c1dc4db7d09053a51a40d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c2c00ef2-1cc4-4bcf-a096-95879e0ebecd
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c2c00ef21cc44bcfa09695879e0ebecd, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c2f7f6a8-8b4c-4f20-a53d-eb72f3d9144c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c2f7f6a88b4c4f20a53deb72f3d9144c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c76700ea-0062-413d-9f69-409b4e9e151b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c76700ea0062413d9f69409b4e9e151b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c82628e7-a85e-39c4-181b-8f4bbc022896
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c91313de-4a57-9684-fb5a-4d33009a2497
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ca51b190-2409-4d1b-87f3-e07edb0a75fb
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ca51b19024094d1b87f3e07edb0a75fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: cd82213f-1cb2-9ac4-0823-f002b56504fa
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: cd82213f1cb29ac40823f002b56504fa, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d0b89fa4-7caf-144e-49c3-ef040cbda163
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d0b89fa47caf144e49c3ef040cbda163, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d31bc7d9-43a7-b954-cb8a-02a129e447f8
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d31bc7d943a7b954cb8a02a129e447f8, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d651fc00-b471-cfe4-4834-a222e9433461
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d651fc00b471cfe44834a222e9433461, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d6cb64fe-b90e-0314-f9c6-e885fcc3d39b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d6cb64feb90e0314f9c6e885fcc3d39b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d74cdc58-c5d1-72a4-69ea-5ca987eb17f6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d74cdc58c5d172a469ea5ca987eb17f6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d7776e47-f36f-9954-58a9-2021b99f44d5
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d7776e47f36f995458a92021b99f44d5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d867b2e3-61e9-0944-b8b1-ee90338f4350
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
+  - AssetId:
+      guid:
+        m_storage: dffef663-76be-4fa4-80fb-02b19edbe903
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e05ace3b-d157-40cd-a0ba-d60d89092a5b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: e05ace3bd15740cda0bad60d89092a5b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e331c375-9dc6-afb4-086a-58238fc6934c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e41f0635-be05-0469-8a18-1d1e71b88691
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: e41f0635be0504698a181d1e71b88691, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eabaead8-25c4-fa84-6947-4a08de620d78
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eaf7f687-2bf5-44df-39a8-14d587c5a63e
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: eaf7f6872bf544df39a814d587c5a63e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ec74779a-ec7b-9eb4-aa02-bc94fe6c78c9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ed041e68-4397-49a6-9d0e-fa0e3d896c2e
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ed041e68439749a69d0efa0e3d896c2e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ed47c1d1-8954-8415-1b10-81f5536df76c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ed47c1d1895484151b1081f5536df76c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ed706df7-5463-c46c-6b50-36d99ca2e8bb
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ed706df75463c46c6b5036d99ca2e8bb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: edf886be-8536-b924-8994-f01ae476fe11
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ee148e28-1f3c-41c5-b4ff-5f8a5afe5a6c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ee148e281f3c41c5b4ff5f8a5afe5a6c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eeb590e9-19d3-5479-097a-ed649f2c5f67
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: eeb590e919d35479097aed649f2c5f67, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f0043074-2d79-7440-1a53-e2867631536b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: f00430742d7974401a53e2867631536b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f2237692-de96-24a4-692e-4b0440c5f476
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: f2237692de9624a4692e4b0440c5f476, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f8eca3a7-11f4-842e-ba0c-52ea9885ef7f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fa6bd40a-2163-46b7-83a4-cce741d277a5
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: fa6bd40a216346b783a4cce741d277a5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fb74736e-21b1-14c6-185e-5536fb3f1c8d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: fb74736e21b114c6185e5536fb3f1c8d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fbd83ab7-1f75-243d-1be6-b4fe8d3f77ce
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: fbd83ab71f75243d1be6b4fe8d3f77ce, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fda1fd92-664e-84e4-38ea-8e4e243c3ddc
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: fda1fd92664e84e438ea8e4e243c3ddc, type: 3}

--- a/samples/SpectatorView.Example.Unity/Assets/ARKit-Unity-Plugin.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/ARKit-Unity-Plugin.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3cd04e5cb8ad8e543b61a0fff4544480
+guid: b6954ada3ab904c2797467a24a765731
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/samples/SpectatorView.Example.Unity/Assets/ARKit-Unity-Plugin.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/ARKit-Unity-Plugin.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b6954ada3ab904c2797467a24a765731
+guid: 3cd04e5cb8ad8e543b61a0fff4544480
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/samples/SpectatorView.Example.Unity/Assets/AzureSpatialAnchors.Resources.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/AzureSpatialAnchors.Resources.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fceaafdfc84353d47be22c38768cf688
+guid: bab902d9c46caa84d8ec40d3cec7c3cd
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/samples/SpectatorView.Example.Unity/Assets/AzureSpatialAnchors.Resources.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/AzureSpatialAnchors.Resources.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bab902d9c46caa84d8ec40d3cec7c3cd
+guid: fceaafdfc84353d47be22c38768cf688
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/samples/SpectatorView.Example.Unity/Assets/AzureSpatialAnchorsPlugin.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/AzureSpatialAnchorsPlugin.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2f841b7408119bb42b918a5dccfc9c0b
+guid: 47f7162fd5e319f42ba5a2a6107c9db7
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/AudioClipAssetCache.asset
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/AudioClipAssetCache.asset
@@ -14,5 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: b8b0ae9d-ae02-4a8c-9882-035a946e0da4
+      guid:
+        m_storage: 269b9f0f-a8c9-30b4-ea7a-e2bf7b250820
+      fileIdentifier: 8300000
     Asset: {fileID: 8300000, guid: 269b9f0fa8c930b4ea7ae2bf7b250820, type: 3}

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/FontAssetCache.asset
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/FontAssetCache.asset
@@ -14,5 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: f92f5bbc-4f76-4f1e-bca6-47980c7c3e59
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10102
     Asset: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MaterialPropertyAssetCache.asset
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MaterialPropertyAssetCache.asset
@@ -13,42 +13,6 @@ MonoBehaviour:
   m_Name: MaterialPropertyAssetCache
   m_EditorClassIdentifier: 
   materialPropertyAssets:
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _Color
-    propertyType: 0
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _StencilComp
-    propertyType: 2
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _Stencil
-    propertyType: 2
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _StencilOp
-    propertyType: 2
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _StencilWriteMask
-    propertyType: 2
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _StencilReadMask
-    propertyType: 2
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _ColorMask
-    propertyType: 2
-  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-    shaderName: UI/Default
-    propertyName: _UseUIAlphaClip
-    propertyType: 2
   - shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
     shaderName: Standard
     propertyName: _Color
@@ -157,6 +121,46 @@ MonoBehaviour:
     shaderName: Standard
     propertyName: _ZWrite
     propertyType: 2
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _Color
+    propertyType: 0
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _StencilComp
+    propertyType: 2
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _Stencil
+    propertyType: 2
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _StencilOp
+    propertyType: 2
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _StencilWriteMask
+    propertyType: 2
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _StencilReadMask
+    propertyType: 2
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _ColorMask
+    propertyType: 2
+  - shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+    shaderName: UI/Default
+    propertyName: _UseUIAlphaClip
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
+    shaderName: SV/RGBToYUV
+    propertyName: _MainTex
+    propertyType: 4
   - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
     shaderName: SV/RGBToYUV
     propertyName: _Width
@@ -173,6 +177,18 @@ MonoBehaviour:
     shaderName: Legacy Shaders/Diffuse Fast
     propertyName: _MainTex
     propertyType: 4
+  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
+    shaderName: SV/AlphaBlend
+    propertyName: _BackTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
+    shaderName: SV/AlphaBlend
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
+    shaderName: SV/AlphaBlend
+    propertyName: _Alpha
+    propertyType: 2
   - shader: {fileID: 4800000, guid: acab126297274c848beb9908fb34d939, type: 3}
     shaderName: SV/Downsample
     propertyName: _MainTex
@@ -197,58 +213,6 @@ MonoBehaviour:
     shaderName: SV/HoloAlpha
     propertyName: _Alpha
     propertyType: 2
-  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
-    shaderName: SV/YUVToRGB
-    propertyName: _Width
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
-    shaderName: SV/YUVToRGB
-    propertyName: _Height
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
-    shaderName: SV/YUVToRGB
-    propertyName: _AlphaScale
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
-    shaderName: SV/RGBToNV12
-    propertyName: _Width
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
-    shaderName: SV/RGBToNV12
-    propertyName: _Height
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: 85fad1b1898fc6c43b34ef1668215c99, type: 3}
-    shaderName: SV/ExtractAlpha
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: ea4b73caa6ce81141a44be6d0a0c6829, type: 3}
-    shaderName: SV/IgnoreAlpha
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
-    shaderName: SV/BGRToRGB
-    propertyName: _AlphaScale
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
-    shaderName: SV/BGRToRGB
-    propertyName: _YFlip
-    propertyType: 2
-  - shader: {fileID: 4800000, guid: b0afe19eb5a14bd4a804a6dcae920c15, type: 3}
-    shaderName: SV/RGBToYUV
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
-    shaderName: SV/AlphaBlend
-    propertyName: _BackTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
-    shaderName: SV/AlphaBlend
-    propertyName: _MainTex
-    propertyType: 4
-  - shader: {fileID: 4800000, guid: 0fa9e48777047104bb4bb8290d6be951, type: 3}
-    shaderName: SV/AlphaBlend
-    propertyName: _Alpha
-    propertyType: 2
   - shader: {fileID: 4800000, guid: 941c5282fb189a4488e0e77278feab21, type: 3}
     shaderName: SV/QuadView
     propertyName: _MainTex
@@ -269,11 +233,47 @@ MonoBehaviour:
     shaderName: SV/YUVToRGB
     propertyName: _MainTex
     propertyType: 4
+  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
+    shaderName: SV/YUVToRGB
+    propertyName: _Width
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
+    shaderName: SV/YUVToRGB
+    propertyName: _Height
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: eea5640f3b88bc740b064fb8e21f7084, type: 3}
+    shaderName: SV/YUVToRGB
+    propertyName: _AlphaScale
+    propertyType: 2
   - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
     shaderName: SV/RGBToNV12
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
+    shaderName: SV/RGBToNV12
+    propertyName: _Width
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: bd694db3311e85043ade9f089995566b, type: 3}
+    shaderName: SV/RGBToNV12
+    propertyName: _Height
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: 85fad1b1898fc6c43b34ef1668215c99, type: 3}
+    shaderName: SV/ExtractAlpha
+    propertyName: _MainTex
+    propertyType: 4
+  - shader: {fileID: 4800000, guid: ea4b73caa6ce81141a44be6d0a0c6829, type: 3}
+    shaderName: SV/IgnoreAlpha
     propertyName: _MainTex
     propertyType: 4
   - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
     shaderName: SV/BGRToRGB
     propertyName: _MainTex
     propertyType: 4
+  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
+    shaderName: SV/BGRToRGB
+    propertyName: _AlphaScale
+    propertyType: 2
+  - shader: {fileID: 4800000, guid: d205647913a7f2247a941d09358bc180, type: 3}
+    shaderName: SV/BGRToRGB
+    propertyName: _YFlip
+    propertyType: 2

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MeshAssetCache.asset
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/MeshAssetCache.asset
@@ -14,17 +14,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: 92883a9b-3133-4aee-883e-6a0fe260fdae
-    Asset: {fileID: 4300000, guid: ce4cfb5a16c86b048bb700360ee47685, type: 3}
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10202
+    Asset: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: ab5f7134-16ff-49bd-823e-a57ce6045546
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10206
     Asset: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 1a708a81-a0a1-46b4-b611-f4aa389221fe
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10207
     Asset: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 7de1c5a0-ac83-47c0-9397-6d6400a5cea9
+      guid:
+        m_storage: 00000000-0000-0000-e000-000000000000
+      fileIdentifier: 10209
     Asset: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
   - AssetId:
-      m_storage: 3e5f8501-f0c8-45d0-82a9-8f0c8297c5b1
-    Asset: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+      guid:
+        m_storage: ce4cfb5a-16c8-6b04-8bb7-00360ee47685
+      fileIdentifier: 4300000
+    Asset: {fileID: 4300000, guid: ce4cfb5a16c86b048bb700360ee47685, type: 3}

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpectatorViewSettings.prefab
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpectatorViewSettings.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &8551012926961121577
+--- !u!1 &2929832388891410874
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,12 +8,12 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5306297162449015195}
-  - component: {fileID: 7822701636223139384}
-  - component: {fileID: 5012277379684556187}
-  - component: {fileID: 7584775395950471591}
-  - component: {fileID: 4690428744344046270}
-  - component: {fileID: 4170170246728063919}
+  - component: {fileID: 1142001103920059233}
+  - component: {fileID: 8817127207551674330}
+  - component: {fileID: 3390207267290998871}
+  - component: {fileID: 3946007032460335880}
+  - component: {fileID: 8557300901145373707}
+  - component: {fileID: 837158114543160490}
   m_Layer: 0
   m_Name: SpectatorViewSettings
   m_TagString: Untagged
@@ -21,13 +21,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5306297162449015195
+--- !u!4 &1142001103920059233
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8551012926961121577}
+  m_GameObject: {fileID: 2929832388891410874}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -35,40 +35,39 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7822701636223139384
+--- !u!114 &8817127207551674330
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8551012926961121577}
+  m_GameObject: {fileID: 2929832388891410874}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 98b6067df2adcbd4c977f3d14b77239c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  automaticallyBroadcastAllGameObjects: 1
---- !u!114 &5012277379684556187
+  automaticallyBroadcastAllGameObjects: 0
+--- !u!114 &3390207267290998871
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8551012926961121577}
+  m_GameObject: {fileID: 2929832388891410874}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7ec336b47b3a517468767a9a595153e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prioritizedInitializers:
-  - {fileID: 4690428744344046270}
---- !u!114 &7584775395950471591
+  prioritizedInitializers: []
+--- !u!114 &3946007032460335880
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8551012926961121577}
+  m_GameObject: {fileID: 2929832388891410874}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e7b4d5c48f786a54fb34ca53054971cf, type: 3}
@@ -76,13 +75,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enableMobileRecordingService: 1
   overrideMobileRecordingServiceVisualPrefab: {fileID: 0}
---- !u!114 &4690428744344046270
+--- !u!114 &8557300901145373707
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8551012926961121577}
+  m_GameObject: {fileID: 2929832388891410874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f9490c8de72d2d44ac469f8bf46fb39, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enableMobileNetworkConfigurationVisual: 1
+  overrideMobileNetworkConfigurationVisualPrefab: {fileID: 0}
+--- !u!114 &837158114543160490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2929832388891410874}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b31b38d11c2c8dc4487ec945d77e000c, type: 3}
@@ -94,17 +107,3 @@ MonoBehaviour:
     AccountKey: ENTER_ACCOUNT_KEY
     AccessToken: 
     AuthenticationToken: 
---- !u!114 &4170170246728063919
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8551012926961121577}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1f9490c8de72d2d44ac469f8bf46fb39, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  enableMobileNetworkConfigurationVisual: 1
-  overrideMobileNetworkConfigurationVisualPrefab: {fileID: 0}

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpectatorViewSettings.prefab.meta
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpectatorViewSettings.prefab.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 2f841b7408119bb42b918a5dccfc9c0b
-folderAsset: yes
-DefaultImporter:
+guid: 7ab15c7e3aa61c2459723563b7123d1f
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpriteAssetCache.asset
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/SpriteAssetCache.asset
@@ -14,101 +14,167 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: cd48bf07-be40-4c3e-9a61-54d27e0e431a
-    Asset: {fileID: 21300000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
-  - AssetId:
-      m_storage: 81334764-6dda-410d-9cbf-ebb4eb92f9b1
-    Asset: {fileID: 21300000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
-  - AssetId:
-      m_storage: 9d580957-e118-4a10-b76c-d8abd1f6dd40
-    Asset: {fileID: 21300000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
-  - AssetId:
-      m_storage: 7626b72d-822c-4ace-be6f-91f3e286f03e
-    Asset: {fileID: 21300000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
-  - AssetId:
-      m_storage: 05821e8f-ea8c-434f-9d13-5281a9769fcc
-    Asset: {fileID: 21300000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
-  - AssetId:
-      m_storage: b87f780f-f06f-458c-b008-1e383997f33e
-    Asset: {fileID: 21300000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
-  - AssetId:
-      m_storage: 8f3c90a6-bd9a-4a7f-933e-05bec2350415
-    Asset: {fileID: 21300000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
-  - AssetId:
-      m_storage: 920e9c97-22e1-4e04-9a95-6a09188b3a44
-    Asset: {fileID: 21300000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
-  - AssetId:
-      m_storage: a6bfe80a-f708-468f-b0db-441896a86a7e
-    Asset: {fileID: 21300000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
-  - AssetId:
-      m_storage: 79cf28aa-5cd4-444d-9705-d28ed04a356f
-    Asset: {fileID: 21300000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
-  - AssetId:
-      m_storage: ca61fa00-27cb-4a09-8846-b3b2eec84675
-    Asset: {fileID: 21300000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
-  - AssetId:
-      m_storage: 4cc79844-f19a-4a8b-831f-91b79c77b529
-    Asset: {fileID: 21300000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
-  - AssetId:
-      m_storage: 1794e820-455a-477c-a795-1676ecb4533e
-    Asset: {fileID: 21300000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
-  - AssetId:
-      m_storage: 09d92c89-0ad8-4f09-9a3f-d9945732a966
-    Asset: {fileID: 21300000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
-  - AssetId:
-      m_storage: 69a6ef73-54e1-4273-a54b-6a9eab6062f6
-    Asset: {fileID: 21300000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
-  - AssetId:
-      m_storage: 41b9e3ea-ca2f-4d65-ac9c-bf2d3aedc163
-    Asset: {fileID: 21300000, guid: 01e02995805eb483690380a911a657e2, type: 3}
-  - AssetId:
-      m_storage: 6b62bf26-f872-4e87-abcf-96c115cfae04
-    Asset: {fileID: 21300000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
-  - AssetId:
-      m_storage: de18a9a6-1539-4453-8e62-f9ae22aa4dea
-    Asset: {fileID: 21300000, guid: 375eed972162232439848c636aab9117, type: 3}
-  - AssetId:
-      m_storage: e058adf5-17bb-47ce-b90c-c9d73723ee47
-    Asset: {fileID: 21300000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}
-  - AssetId:
-      m_storage: 6830a2ba-4314-4362-a8a6-ff4e61eeb043
-    Asset: {fileID: 21300000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
-  - AssetId:
-      m_storage: a4788342-321c-4f8d-9cac-6ab13e5a5503
-    Asset: {fileID: 21300000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
-  - AssetId:
-      m_storage: e3f7a869-7ba2-4418-933d-ea47f5aa3e65
-    Asset: {fileID: 21300000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
-  - AssetId:
-      m_storage: 85fd1b40-9c43-4eac-ae0c-1e52f2140870
-    Asset: {fileID: 21300000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
-  - AssetId:
-      m_storage: 32525d27-dd8f-404c-9407-f12ab8526c19
-    Asset: {fileID: 21300000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
-  - AssetId:
-      m_storage: 7c7396c5-896d-4759-a54b-7a8c904b7a73
-    Asset: {fileID: 21300000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
-  - AssetId:
-      m_storage: 52f1dd6d-6e23-4748-928e-c91a79f49604
-    Asset: {fileID: 21300000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
-  - AssetId:
-      m_storage: 3961c92c-43a3-48ea-815e-324be7878dbd
-    Asset: {fileID: 21300000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
-  - AssetId:
-      m_storage: d825034d-8180-4301-86af-156b36f4ac47
-    Asset: {fileID: 21300000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
-  - AssetId:
-      m_storage: 6a82979e-86c0-4141-82c3-6e36668b787a
-    Asset: {fileID: 21300000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
-  - AssetId:
-      m_storage: c9d9f96f-9fa4-46fc-95cb-238fba78cbc4
-    Asset: {fileID: 21300000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
-  - AssetId:
-      m_storage: 8af0b3db-851f-4615-ac5c-e351332d73a3
+      guid:
+        m_storage: 00000000-0000-0000-f000-000000000000
+      fileIdentifier: 10905
     Asset: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
   - AssetId:
-      m_storage: 858d7154-5985-4122-863a-f8a45147b271
+      guid:
+        m_storage: 01e02995-805e-b483-6903-80a911a657e2
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 01e02995805eb483690380a911a657e2, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 0ac4e434-e8bf-54a4-18c7-e6ff28cdf07b
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 1520ffe2-2e03-8294-9b34-d64a73900077
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 229c3211-a796-6124-ca2b-aa412fae0b0f
+      fileIdentifier: 21300000
     Asset: {fileID: 21300000, guid: 229c3211a7966124ca2baa412fae0b0f, type: 3}
   - AssetId:
-      m_storage: d97643f7-dcfd-405c-bd60-04c6a36801c0
+      guid:
+        m_storage: 2e1868a1-5829-5364-59f5-d0022d6ec0b5
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 375eed97-2162-2324-3984-8c636aab9117
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 375eed972162232439848c636aab9117, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3ba76ce0-e2c9-a7c4-5801-facdc7e24384
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3cf132d4-fa07-f4f0-cb28-83499c5c7dd0
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 426a1fee-d732-8674-1995-65d08aa1abe4
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4af5db22-4464-bf34-cb8f-dc70ee470b65
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4c433abc-db28-444e-bb7b-d395ba5c76fc
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4dfd3f5d-a889-44ec-6ac5-977d676c30c6
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 599a5fd9-2bab-81a4-ab02-e52d0b1b1c60
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 61438131-b4fd-ac44-6a91-f664f1770aad
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6344c474-9a58-54a4-fb03-3def626a8547
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6deea620-179c-aad4-d97d-51e0e6e03010
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 739d0ad3-b6c1-0dc4-9b8a-45caf9002249
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a0da391-9302-1fa4-cb9b-71d883d30b97
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a86432c-6c39-2234-79e7-d6b663242ae9
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: acc34040-a66f-e417-0bc8-885268860cfe
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b2c8cdd0-abb0-99e4-3b24-fe3c1944e166
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b7c2f847-b307-3494-5a20-fd895bfd2717
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b866a23e-6fb7-94a4-5bb5-71ce249f1c93
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c82628e7-a85e-39c4-181b-8f4bbc022896
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c91313de-4a57-9684-fb5a-4d33009a2497
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d6cb64fe-b90e-0314-f9c6-e885fcc3d39b
+      fileIdentifier: 21300000
     Asset: {fileID: 21300000, guid: d6cb64feb90e0314f9c6e885fcc3d39b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d867b2e3-61e9-0944-b8b1-ee90338f4350
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e331c375-9dc6-afb4-086a-58238fc6934c
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eabaead8-25c4-fa84-6947-4a08de620d78
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ec74779a-ec7b-9eb4-aa02-bc94fe6c78c9
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: edf886be-8536-b924-8994-f01ae476fe11
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f8eca3a7-11f4-842e-ba0c-52ea9885ef7f
+      fileIdentifier: 21300000
+    Asset: {fileID: 21300000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}

--- a/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/TextureAssetCache.asset
+++ b/samples/SpectatorView.Example.Unity/Assets/Generated.StateSynchronization.AssetCaches/Resources/TextureAssetCache.asset
@@ -14,257 +14,427 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   assets:
   - AssetId:
-      m_storage: a4732b41-13c1-4ba5-a2ab-2cb165d779d1
-    Asset: {fileID: 2800000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
-  - AssetId:
-      m_storage: 24545079-25fd-42d4-98ce-3e71d22d8f26
-    Asset: {fileID: 2800000, guid: 49679f302ac6408697f6b9314a38985c, type: 3}
-  - AssetId:
-      m_storage: efe91bef-f659-4d95-af28-ab4019020c5e
-    Asset: {fileID: 2800000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
-  - AssetId:
-      m_storage: 3e9c2ee1-8212-4468-b7a8-10bc44e7d066
-    Asset: {fileID: 2800000, guid: 0ece3980a49844bf181847eac75da121, type: 3}
-  - AssetId:
-      m_storage: c0f7014b-ee1e-449a-9cfe-f204be222ef4
-    Asset: {fileID: 2800000, guid: ca51b19024094d1b87f3e07edb0a75fb, type: 3}
-  - AssetId:
-      m_storage: d6ce1f87-6477-4447-a7d5-caaafff4c746
-    Asset: {fileID: 2800000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
-  - AssetId:
-      m_storage: 354e1cf4-3911-48a1-944d-97aeeb80f26f
-    Asset: {fileID: 2800000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
-  - AssetId:
-      m_storage: 03586ade-19a7-4445-9627-2a4affaaf778
-    Asset: {fileID: 2800000, guid: 0d9a36012a224080966c7b55896aa0f9, type: 3}
-  - AssetId:
-      m_storage: 535b929f-d3f7-4364-afc1-30a709f8382b
-    Asset: {fileID: 2800000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
-  - AssetId:
-      m_storage: 126b7cbd-2859-4b78-8e19-e301cedb61a3
-    Asset: {fileID: 2800000, guid: 18775b51e3bd42299fd30bd036ea982f, type: 3}
-  - AssetId:
-      m_storage: 35917167-e83b-49be-a8ab-751793792bb7
-    Asset: {fileID: 2800000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
-  - AssetId:
-      m_storage: ff4c3b40-e2f8-4a54-afb5-fe17a8c88fb3
-    Asset: {fileID: 2800000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
-  - AssetId:
-      m_storage: 24439c52-d7c7-43e9-80c5-9c686cc5ffef
-    Asset: {fileID: 2800000, guid: ed47c1d1895484151b1081f5536df76c, type: 3}
-  - AssetId:
-      m_storage: 16ad395f-5414-4338-8bc8-4ee283570134
-    Asset: {fileID: 2800000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
-  - AssetId:
-      m_storage: 9ce08fc6-b6a5-47d4-89b5-b83d0ede5856
-    Asset: {fileID: 2800000, guid: 8bc1f0e2862754e4492fa0179903ce74, type: 3}
-  - AssetId:
-      m_storage: 767f75fe-f1f4-4dbb-adea-1d1637fa4c71
-    Asset: {fileID: 2800000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
-  - AssetId:
-      m_storage: cf85ebe2-e56e-4879-bcb6-bc5da85b89ed
-    Asset: {fileID: 2800000, guid: 6ace62d30f494c948b71d5594afce11d, type: 3}
-  - AssetId:
-      m_storage: 1403bfd5-6b30-4744-9172-54c5db1ad9f1
-    Asset: {fileID: 2800000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
-  - AssetId:
-      m_storage: f6afebf2-7f7d-4915-9d26-883ac2d1213b
-    Asset: {fileID: 2800000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
-  - AssetId:
-      m_storage: 427cf535-a68d-498e-8169-97c1ba52025c
-    Asset: {fileID: 2800000, guid: 41b96614b2e6494ba995ddcd252d11ae, type: 3}
-  - AssetId:
-      m_storage: dcae42ff-e2b0-48df-a536-40bc234b25e9
-    Asset: {fileID: 2800000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
-  - AssetId:
-      m_storage: b768be2d-655a-4b69-8d07-6c48c9431ef2
-    Asset: {fileID: 2800000, guid: f00430742d7974401a53e2867631536b, type: 3}
-  - AssetId:
-      m_storage: 15d85249-a87c-42c4-8dfe-5ee756cba484
-    Asset: {fileID: 2800000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
-  - AssetId:
-      m_storage: e670bf1f-1d22-4987-a4e4-5a4c099be14d
-    Asset: {fileID: 2800000, guid: d0b89fa47caf144e49c3ef040cbda163, type: 3}
-  - AssetId:
-      m_storage: 01122d70-c52f-401c-8592-e817f5cf0be5
-    Asset: {fileID: 2800000, guid: 48d034c499ee4697af9dd6e327110249, type: 3}
-  - AssetId:
-      m_storage: c4c6666a-b9ab-47e1-95cc-31244f8c674a
-    Asset: {fileID: 2800000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
-  - AssetId:
-      m_storage: 4b473409-bf59-487e-9c1c-c61b090ff01c
-    Asset: {fileID: 2800000, guid: e41f0635be0504698a181d1e71b88691, type: 3}
-  - AssetId:
-      m_storage: 59ea506c-58e4-4e05-9408-51685d5ff718
-    Asset: {fileID: 2800000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
-  - AssetId:
-      m_storage: 7acfba9f-3d7a-4f25-93ce-8b27c2e4ece6
+      guid:
+        m_storage: 01e02995-805e-b483-6903-80a911a657e2
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 01e02995805eb483690380a911a657e2, type: 3}
   - AssetId:
-      m_storage: c91e8384-3749-4514-9f17-7d6df104781b
-    Asset: {fileID: 2800000, guid: 691475c57a824010be0c6f474caeb7e1, type: 3}
-  - AssetId:
-      m_storage: 7bd028d4-cb14-4bfd-85a1-c5acd6fc6706
-    Asset: {fileID: 2800000, guid: bb353ac508e7c4201a260e00d69e1daf, type: 3}
-  - AssetId:
-      m_storage: bd95e71d-f04d-47cb-9631-af87afdaef36
-    Asset: {fileID: 2800000, guid: 8847dee5697a04f749b9ec611224ac4d, type: 3}
-  - AssetId:
-      m_storage: 03b9a11e-4ce0-4166-b5e0-9db672113f21
-    Asset: {fileID: 2800000, guid: 10bf81265ad87424d946598c575f45a0, type: 3}
-  - AssetId:
-      m_storage: a04ae0f8-1215-4da7-acbb-d8724aa9c65a
-    Asset: {fileID: 2800000, guid: 81ed8c76d2bc4a4c95d092c98af4e58f, type: 3}
-  - AssetId:
-      m_storage: a244ce32-061d-48e0-bfd5-ad0945d3c060
-    Asset: {fileID: 2800000, guid: 64b9fad609434c489c32b1cdf2004a1c, type: 3}
-  - AssetId:
-      m_storage: 942de632-72c3-4c68-88f1-416e58c06de7
-    Asset: {fileID: 2800000, guid: 35ff0937876540d3bd4b6a941df62a92, type: 3}
-  - AssetId:
-      m_storage: bc247b75-f812-48fd-960c-28205a29a9df
-    Asset: {fileID: 2800000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
-  - AssetId:
-      m_storage: c908a53d-afd1-45aa-a4ca-ee9f56c6b5e8
-    Asset: {fileID: 2800000, guid: eaf7f6872bf544df39a814d587c5a63e, type: 3}
-  - AssetId:
-      m_storage: efe0d59c-3473-446e-97ad-2409d3a83288
-    Asset: {fileID: 2800000, guid: 375eed972162232439848c636aab9117, type: 3}
-  - AssetId:
-      m_storage: e8336910-74e0-4135-a873-376a43ebe8f1
-    Asset: {fileID: 2800000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}
-  - AssetId:
-      m_storage: b39ae8d3-cd9a-4192-9172-934b840355bc
-    Asset: {fileID: 2800000, guid: 3ee40aa79cd242a5b53b0b0ca4f13f0f, type: 3}
-  - AssetId:
-      m_storage: de28130c-a614-4071-afaa-6c5b92fd287a
-    Asset: {fileID: 2800000, guid: fbd83ab71f75243d1be6b4fe8d3f77ce, type: 3}
-  - AssetId:
-      m_storage: b2029af3-dab5-4db1-b9e8-8f3217f26ebf
-    Asset: {fileID: 2800000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
-  - AssetId:
-      m_storage: 51215dfb-5af1-4300-897d-82ae4c6630e9
-    Asset: {fileID: 2800000, guid: ed706df75463c46c6b5036d99ca2e8bb, type: 3}
-  - AssetId:
-      m_storage: d245d931-bb65-40ad-bca1-ade4f807b676
-    Asset: {fileID: 2800000, guid: ee148e281f3c41c5b4ff5f8a5afe5a6c, type: 3}
-  - AssetId:
-      m_storage: 589bf9eb-740e-458d-8f3b-4f75f969c123
-    Asset: {fileID: 2800000, guid: ed041e68439749a69d0efa0e3d896c2e, type: 3}
-  - AssetId:
-      m_storage: 09f658e9-dcb7-4150-ba22-7c9e18837028
-    Asset: {fileID: 2800000, guid: a25aa578421df4048adb5146b2f8f9c1, type: 3}
-  - AssetId:
-      m_storage: b22552bb-57fc-4187-9987-d40f31625333
-    Asset: {fileID: 2800000, guid: 12736c98af174f91827a26b66d2b01b9, type: 3}
-  - AssetId:
-      m_storage: d142dccb-cd86-42f1-93e3-237403563a43
-    Asset: {fileID: 2800000, guid: c2f7f6a88b4c4f20a53deb72f3d9144c, type: 3}
-  - AssetId:
-      m_storage: 1d1d0016-df78-4cfc-be21-b8c7eab88354
-    Asset: {fileID: 2800000, guid: 4c4008a8f878545798c76e17b4faf755, type: 3}
-  - AssetId:
-      m_storage: bafa9ae2-2447-43f4-8b7a-9bb2acd84b22
-    Asset: {fileID: 2800000, guid: 2e6ca3c8f061c498999fc725a892986c, type: 3}
-  - AssetId:
-      m_storage: 050b9cce-f3d4-4f0c-8a69-861ef3b835a6
-    Asset: {fileID: 2800000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
-  - AssetId:
-      m_storage: cb795153-b097-4735-bc49-6a2be7cae88a
-    Asset: {fileID: 2800000, guid: 5e7c9ab97e5884e4eaa5967e9024f39d, type: 3}
-  - AssetId:
-      m_storage: 1272195f-4417-4d13-a1b3-dd7d6cc5394c
-    Asset: {fileID: 2800000, guid: 066619c9c9c84f89acb1b48c11a7efe2, type: 3}
-  - AssetId:
-      m_storage: 1c2d07d3-25c2-4e3b-881b-ed07c824f447
-    Asset: {fileID: 2800000, guid: bb42b2d967d6427983c901a4ffc8ecd9, type: 3}
-  - AssetId:
-      m_storage: 4f9bbe25-8f4d-489d-952a-3e3c6d78e4c0
-    Asset: {fileID: 2800000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
-  - AssetId:
-      m_storage: 97bf1237-64db-4023-b26a-076161fc5adc
-    Asset: {fileID: 2800000, guid: eeb590e919d35479097aed649f2c5f67, type: 3}
-  - AssetId:
-      m_storage: 62a7bd21-52d9-4f97-9cdc-99bf0f427e3e
-    Asset: {fileID: 2800000, guid: fa6bd40a216346b783a4cce741d277a5, type: 3}
-  - AssetId:
-      m_storage: 8e6090d7-3404-4b12-9876-f2db8747d7c0
-    Asset: {fileID: 2800000, guid: a7ec9e7ad8b847b7ae4510af83c5d868, type: 3}
-  - AssetId:
-      m_storage: b6c63b41-1361-4974-951f-59bfae7ff749
-    Asset: {fileID: 2800000, guid: 342a0f8aca7f4f0691338912faec0494, type: 3}
-  - AssetId:
-      m_storage: 2f73d16f-f4b1-4fff-b78c-c00a5652f895
-    Asset: {fileID: 2800000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
-  - AssetId:
-      m_storage: 897c8ea6-1c90-4269-a374-419d867c3859
-    Asset: {fileID: 2800000, guid: c76700ea0062413d9f69409b4e9e151b, type: 3}
-  - AssetId:
-      m_storage: 0d280f7a-c802-48a5-b042-febe96ce0b21
-    Asset: {fileID: 2800000, guid: e05ace3bd15740cda0bad60d89092a5b, type: 3}
-  - AssetId:
-      m_storage: f0f5c45d-dd5b-4e8c-84d6-a532b222e964
-    Asset: {fileID: 2800000, guid: 8bc445bb79654bf496c92d0407840a92, type: 3}
-  - AssetId:
-      m_storage: 9bcfe98e-3e82-4ecc-9cca-08f421389cb3
-    Asset: {fileID: 2800000, guid: 585b70cb75dd43efbfead809c30a1731, type: 3}
-  - AssetId:
-      m_storage: cd1b0dc4-7f3e-46a1-89ad-c75e4a2ca08a
-    Asset: {fileID: 2800000, guid: 526ca60c7581842aaa0b7d34bc14f740, type: 3}
-  - AssetId:
-      m_storage: eb22e2c9-ca52-4896-b95c-5c6f4466621b
-    Asset: {fileID: 2800000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
-  - AssetId:
-      m_storage: 15ba0302-d714-4a02-95ca-95a14aec79b5
-    Asset: {fileID: 2800000, guid: 9288066c33474b94b6ee5465f4df1cc0, type: 3}
-  - AssetId:
-      m_storage: 77c4638e-1273-4e07-81db-5e82a177d49a
-    Asset: {fileID: 2800000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
-  - AssetId:
-      m_storage: bd27c65e-6158-4bc3-828c-49625112d283
-    Asset: {fileID: 2800000, guid: 19436f0d867684b8e8c9e9486c16f3b6, type: 3}
-  - AssetId:
-      m_storage: 227c5c3b-1303-485e-aa17-f885d28446c3
-    Asset: {fileID: 2800000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
-  - AssetId:
-      m_storage: 6c7389b1-34dd-4131-9a9a-ed4aa9a885b5
+      guid:
+        m_storage: 0368159d-8401-d4bf-f81b-9c85d4730446
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 0368159d8401d4bff81b9c85d4730446, type: 3}
   - AssetId:
-      m_storage: b1ab863e-5cff-4e36-ae37-790d62bb57fd
-    Asset: {fileID: 2800000, guid: bb0617bde6c534c3abc7c6bce648c578, type: 3}
+      guid:
+        m_storage: 066619c9-c9c8-4f89-acb1-b48c11a7efe2
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 066619c9c9c84f89acb1b48c11a7efe2, type: 3}
   - AssetId:
-      m_storage: 132f3e06-a0b4-412b-8f0b-c4dc5951d653
-    Asset: {fileID: 2800000, guid: a54eac0e085a44468963fa57f209470d, type: 3}
+      guid:
+        m_storage: 0ac4e434-e8bf-54a4-18c7-e6ff28cdf07b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0ac4e434e8bf54a418c7e6ff28cdf07b, type: 3}
   - AssetId:
-      m_storage: 3dce4bac-e5c5-4e09-b802-e7ae85ae702d
-    Asset: {fileID: 2800000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
+      guid:
+        m_storage: 0d9a3601-2a22-4080-966c-7b55896aa0f9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0d9a36012a224080966c7b55896aa0f9, type: 3}
   - AssetId:
-      m_storage: 43e5f5f2-17dd-42d3-aeed-dfdb5ba9438a
-    Asset: {fileID: 2800000, guid: fb74736e21b114c6185e5536fb3f1c8d, type: 3}
+      guid:
+        m_storage: 0ece3980-a498-44bf-1818-47eac75da121
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 0ece3980a49844bf181847eac75da121, type: 3}
   - AssetId:
-      m_storage: ccc0e7f3-ac1d-4491-9e71-d86037e5f11e
-    Asset: {fileID: 2800000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
+      guid:
+        m_storage: 10bf8126-5ad8-7424-d946-598c575f45a0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 10bf81265ad87424d946598c575f45a0, type: 3}
   - AssetId:
-      m_storage: d072b8a5-b094-4476-8153-f154d42a450a
+      guid:
+        m_storage: 12736c98-af17-4f91-827a-26b66d2b01b9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 12736c98af174f91827a26b66d2b01b9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 1520ffe2-2e03-8294-9b34-d64a73900077
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 1520ffe22e0382949b34d64a73900077, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 18775b51-e3bd-4229-9fd3-0bd036ea982f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 18775b51e3bd42299fd30bd036ea982f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 19436f0d-8676-84b8-e8c9-e9486c16f3b6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 19436f0d867684b8e8c9e9486c16f3b6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 1b32bcce-201b-4494-ea88-48326290c5d5
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 1b32bcce201b4494ea8848326290c5d5, type: 3}
   - AssetId:
-      m_storage: 7e8bf71c-c452-45f2-9aaa-7537fa78608a
-    Asset: {fileID: 2800000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
-  - AssetId:
-      m_storage: ad63d462-9cfc-4514-a362-5bb49bb2cb2f
-    Asset: {fileID: 2800000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
-  - AssetId:
-      m_storage: 2868eb05-a15f-42ef-af42-11e5cf27d76e
-    Asset: {fileID: 2800000, guid: 2fd6421f253b4ef1a19526541f9ffc0c, type: 3}
-  - AssetId:
-      m_storage: 5ebd8ad7-4794-4600-bde7-08e3ebedffc9
-    Asset: {fileID: 2800000, guid: 92027f7f8cfc4feaa477da0dc38d3d46, type: 3}
-  - AssetId:
-      m_storage: 1cfad1ce-e2d3-4703-b93a-a320d20db41a
-    Asset: {fileID: 2800000, guid: bcdf3dcffa0c744c9adf933757702ab6, type: 3}
-  - AssetId:
-      m_storage: 9d00b812-6788-412e-83fb-cebda1926985
+      guid:
+        m_storage: 229c3211-a796-6124-ca2b-aa412fae0b0f
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: 229c3211a7966124ca2baa412fae0b0f, type: 3}
   - AssetId:
-      m_storage: 680030b0-d918-4338-8bc7-463c678c76df
+      guid:
+        m_storage: 2e1868a1-5829-5364-59f5-d0022d6ec0b5
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2e1868a15829536459f5d0022d6ec0b5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2e6ca3c8-f061-c498-999f-c725a892986c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2e6ca3c8f061c498999fc725a892986c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 2fd6421f-253b-4ef1-a195-26541f9ffc0c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 2fd6421f253b4ef1a19526541f9ffc0c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 342a0f8a-ca7f-4f06-9133-8912faec0494
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 342a0f8aca7f4f0691338912faec0494, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 35ff0937-8765-40d3-bd4b-6a941df62a92
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 35ff0937876540d3bd4b6a941df62a92, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 375eed97-2162-2324-3984-8c636aab9117
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 375eed972162232439848c636aab9117, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3ba76ce0-e2c9-a7c4-5801-facdc7e24384
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3ba76ce0e2c9a7c45801facdc7e24384, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3cf132d4-fa07-f4f0-cb28-83499c5c7dd0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3cf132d4fa07f4f0cb2883499c5c7dd0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 3ee40aa7-9cd2-42a5-b53b-0b0ca4f13f0f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 3ee40aa79cd242a5b53b0b0ca4f13f0f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 41b96614-b2e6-494b-a995-ddcd252d11ae
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 41b96614b2e6494ba995ddcd252d11ae, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 426a1fee-d732-8674-1995-65d08aa1abe4
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 426a1feed7328674199565d08aa1abe4, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 48d034c4-99ee-4697-af9d-d6e327110249
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 48d034c499ee4697af9dd6e327110249, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 49679f30-2ac6-4086-97f6-b9314a38985c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 49679f302ac6408697f6b9314a38985c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4af5db22-4464-bf34-cb8f-dc70ee470b65
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4af5db224464bf34cb8fdc70ee470b65, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4c4008a8-f878-5457-98c7-6e17b4faf755
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4c4008a8f878545798c76e17b4faf755, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4c433abc-db28-444e-bb7b-d395ba5c76fc
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4c433abcdb28444ebb7bd395ba5c76fc, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 4dfd3f5d-a889-44ec-6ac5-977d676c30c6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 4dfd3f5da88944ec6ac5977d676c30c6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 526ca60c-7581-842a-aa0b-7d34bc14f740
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 526ca60c7581842aaa0b7d34bc14f740, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 585b70cb-75dd-43ef-bfea-d809c30a1731
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 585b70cb75dd43efbfead809c30a1731, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 599a5fd9-2bab-81a4-ab02-e52d0b1b1c60
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 599a5fd92bab81a4ab02e52d0b1b1c60, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 5e7c9ab9-7e58-84e4-eaa5-967e9024f39d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 5e7c9ab97e5884e4eaa5967e9024f39d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 61438131-b4fd-ac44-6a91-f664f1770aad
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 61438131b4fdac446a91f664f1770aad, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6344c474-9a58-54a4-fb03-3def626a8547
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6344c4749a5854a4fb033def626a8547, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 64b9fad6-0943-4c48-9c32-b1cdf2004a1c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 64b9fad609434c489c32b1cdf2004a1c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 691475c5-7a82-4010-be0c-6f474caeb7e1
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 691475c57a824010be0c6f474caeb7e1, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6ace62d3-0f49-4c94-8b71-d5594afce11d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6ace62d30f494c948b71d5594afce11d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 6deea620-179c-aad4-d97d-51e0e6e03010
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 6deea620179caad4d97d51e0e6e03010, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 739d0ad3-b6c1-0dc4-9b8a-45caf9002249
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 739d0ad3b6c10dc49b8a45caf9002249, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 81ed8c76-d2bc-4a4c-95d0-92c98af4e58f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 81ed8c76d2bc4a4c95d092c98af4e58f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8847dee5-697a-04f7-49b9-ec611224ac4d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8847dee5697a04f749b9ec611224ac4d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a0da391-9302-1fa4-cb9b-71d883d30b97
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8a0da39193021fa4cb9b71d883d30b97, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8a86432c-6c39-2234-79e7-d6b663242ae9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8a86432c6c39223479e7d6b663242ae9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8bc1f0e2-8627-54e4-492f-a0179903ce74
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8bc1f0e2862754e4492fa0179903ce74, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 8bc445bb-7965-4bf4-96c9-2d0407840a92
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 8bc445bb79654bf496c92d0407840a92, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 92027f7f-8cfc-4fea-a477-da0dc38d3d46
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 92027f7f8cfc4feaa477da0dc38d3d46, type: 3}
+  - AssetId:
+      guid:
+        m_storage: 9288066c-3347-4b94-b6ee-5465f4df1cc0
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: 9288066c33474b94b6ee5465f4df1cc0, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a25aa578-421d-f404-8adb-5146b2f8f9c1
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a25aa578421df4048adb5146b2f8f9c1, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a54eac0e-085a-4446-8963-fa57f209470d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a54eac0e085a44468963fa57f209470d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: a7ec9e7a-d8b8-47b7-ae45-10af83c5d868
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: a7ec9e7ad8b847b7ae4510af83c5d868, type: 3}
+  - AssetId:
+      guid:
+        m_storage: acc34040-a66f-e417-0bc8-885268860cfe
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: acc34040a66fe4170bc8885268860cfe, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b2c8cdd0-abb0-99e4-3b24-fe3c1944e166
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b2c8cdd0abb099e43b24fe3c1944e166, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b7c2f847-b307-3494-5a20-fd895bfd2717
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b7c2f847b30734945a20fd895bfd2717, type: 3}
+  - AssetId:
+      guid:
+        m_storage: b866a23e-6fb7-94a4-5bb5-71ce249f1c93
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: b866a23e6fb794a45bb571ce249f1c93, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bb0617bd-e6c5-34c3-abc7-c6bce648c578
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bb0617bde6c534c3abc7c6bce648c578, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bb353ac5-08e7-c420-1a26-0e00d69e1daf
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bb353ac508e7c4201a260e00d69e1daf, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bb42b2d9-67d6-4279-83c9-01a4ffc8ecd9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bb42b2d967d6427983c901a4ffc8ecd9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: bcdf3dcf-fa0c-744c-9adf-933757702ab6
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: bcdf3dcffa0c744c9adf933757702ab6, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c2f7f6a8-8b4c-4f20-a53d-eb72f3d9144c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c2f7f6a88b4c4f20a53deb72f3d9144c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c76700ea-0062-413d-9f69-409b4e9e151b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c76700ea0062413d9f69409b4e9e151b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c82628e7-a85e-39c4-181b-8f4bbc022896
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c82628e7a85e39c4181b8f4bbc022896, type: 3}
+  - AssetId:
+      guid:
+        m_storage: c91313de-4a57-9684-fb5a-4d33009a2497
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: c91313de4a579684fb5a4d33009a2497, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ca51b190-2409-4d1b-87f3-e07edb0a75fb
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ca51b19024094d1b87f3e07edb0a75fb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d0b89fa4-7caf-144e-49c3-ef040cbda163
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d0b89fa47caf144e49c3ef040cbda163, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d6cb64fe-b90e-0314-f9c6-e885fcc3d39b
+      fileIdentifier: 2800000
     Asset: {fileID: 2800000, guid: d6cb64feb90e0314f9c6e885fcc3d39b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: d867b2e3-61e9-0944-b8b1-ee90338f4350
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: d867b2e361e90944b8b1ee90338f4350, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e05ace3b-d157-40cd-a0ba-d60d89092a5b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: e05ace3bd15740cda0bad60d89092a5b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e331c375-9dc6-afb4-086a-58238fc6934c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: e331c3759dc6afb4086a58238fc6934c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: e41f0635-be05-0469-8a18-1d1e71b88691
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: e41f0635be0504698a181d1e71b88691, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eabaead8-25c4-fa84-6947-4a08de620d78
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: eabaead825c4fa8469474a08de620d78, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eaf7f687-2bf5-44df-39a8-14d587c5a63e
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: eaf7f6872bf544df39a814d587c5a63e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ec74779a-ec7b-9eb4-aa02-bc94fe6c78c9
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ec74779aec7b9eb4aa02bc94fe6c78c9, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ed041e68-4397-49a6-9d0e-fa0e3d896c2e
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ed041e68439749a69d0efa0e3d896c2e, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ed47c1d1-8954-8415-1b10-81f5536df76c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ed47c1d1895484151b1081f5536df76c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ed706df7-5463-c46c-6b50-36d99ca2e8bb
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ed706df75463c46c6b5036d99ca2e8bb, type: 3}
+  - AssetId:
+      guid:
+        m_storage: edf886be-8536-b924-8994-f01ae476fe11
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: edf886be8536b9248994f01ae476fe11, type: 3}
+  - AssetId:
+      guid:
+        m_storage: ee148e28-1f3c-41c5-b4ff-5f8a5afe5a6c
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: ee148e281f3c41c5b4ff5f8a5afe5a6c, type: 3}
+  - AssetId:
+      guid:
+        m_storage: eeb590e9-19d3-5479-097a-ed649f2c5f67
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: eeb590e919d35479097aed649f2c5f67, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f0043074-2d79-7440-1a53-e2867631536b
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: f00430742d7974401a53e2867631536b, type: 3}
+  - AssetId:
+      guid:
+        m_storage: f8eca3a7-11f4-842e-ba0c-52ea9885ef7f
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: f8eca3a711f4842eba0c52ea9885ef7f, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fa6bd40a-2163-46b7-83a4-cce741d277a5
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: fa6bd40a216346b783a4cce741d277a5, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fb74736e-21b1-14c6-185e-5536fb3f1c8d
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: fb74736e21b114c6185e5536fb3f1c8d, type: 3}
+  - AssetId:
+      guid:
+        m_storage: fbd83ab7-1f75-243d-1be6-b4fe8d3f77ce
+      fileIdentifier: 2800000
+    Asset: {fileID: 2800000, guid: fbd83ab71f75243d1be6b4fe8d3f77ce, type: 3}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
@@ -261,6 +261,9 @@ namespace Microsoft.MixedReality.SpectatorView
 #endif
         }
 
+        /// <summary>
+        /// Assets are ordered in their associated AssetCache by AssetId (first by file identifier, then by guid).
+        /// </summary>
         public override void UpdateAssetCache()
         {
 #if UNITY_EDITOR

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using UnityEngine;
 using System.IO;
 using UnityEngine.SceneManagement;
+using System.Reflection;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -180,10 +181,10 @@ namespace Microsoft.MixedReality.SpectatorView
         [SerializeField]
         private TAssetEntry[] assets = null;
 
-        private Dictionary<Guid, TAssetEntry> lookupByAssetId;
+        private Dictionary<AssetId, TAssetEntry> lookupByAssetId;
         private Dictionary<TAsset, TAssetEntry> lookupByAsset;
 
-        protected IDictionary<Guid, TAssetEntry> LookupByAssetId
+        protected IDictionary<AssetId, TAssetEntry> LookupByAssetId
         {
             get
             {
@@ -191,11 +192,11 @@ namespace Microsoft.MixedReality.SpectatorView
                 {
                     if (assets == null)
                     {
-                        lookupByAssetId = new Dictionary<Guid, TAssetEntry>();
+                        lookupByAssetId = new Dictionary<AssetId, TAssetEntry>();
                     }
                     else
                     {
-                        lookupByAssetId = assets.Where(a => a.Asset != null).ToDictionary(a => (Guid)a.AssetId);
+                        lookupByAssetId = assets.Where(a => a.Asset != null).ToDictionary(a => a.AssetId);
                     }
                 }
                 return lookupByAssetId;
@@ -221,7 +222,7 @@ namespace Microsoft.MixedReality.SpectatorView
             }
         }
 
-        public TAsset GetAsset(Guid assetId)
+        public TAsset GetAsset(AssetId assetId)
         {
             TAssetEntry assetEntry;
             if (LookupByAssetId.TryGetValue(assetId, out assetEntry))
@@ -234,7 +235,7 @@ namespace Microsoft.MixedReality.SpectatorView
             }
         }
 
-        public Guid GetAssetId(TAsset asset)
+        public AssetId GetAssetId(TAsset asset)
         {
             TAssetEntry assetEntry;
             if (asset != null && LookupByAsset.TryGetValue(asset, out assetEntry))
@@ -243,7 +244,7 @@ namespace Microsoft.MixedReality.SpectatorView
             }
             else
             {
-                return Guid.Empty;
+                return AssetId.Empty;
             }
         }
 
@@ -272,16 +273,23 @@ namespace Microsoft.MixedReality.SpectatorView
                 unvisitedAssets.Remove(asset);
                 if (!oldAssets.ContainsKey(asset))
                 {
-                    oldAssets.Add(asset, new TAssetEntry
+                    if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(asset, out string guid, out long localid))
                     {
-                        AssetId = Guid.NewGuid(),
-                        Asset = asset
-                    });
+                        oldAssets.Add(asset, new TAssetEntry
+                        {
+                            AssetId = new AssetId(new Guid(guid), localid),
+                            Asset = asset
+                        });
+                    }
+                    else
+                    {
+                        Debug.LogError($"Unable to obtain id for Asset: {asset.ToString()}");
+                    }
                 }
             }
 
             CleanUpUnused(oldAssets, unvisitedAssets);
-            assets = oldAssets.Values.ToArray();
+            assets = oldAssets.Values.OrderBy(x => x.AssetId.FileIdentifier).ThenBy(x => x.AssetId.Guid).ToArray();
 
             EditorUtility.SetDirty(this);
 #endif

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCacheEntry.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCacheEntry.cs
@@ -1,11 +1,76 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using UnityEngine;
+
 namespace Microsoft.MixedReality.SpectatorView
 {
+    [Serializable]
+    internal class AssetId
+    {
+        public static AssetId Empty { get; } = new AssetId(System.Guid.Empty, -1);
+
+        public StringGuid Guid => guid;
+
+        [SerializeField]
+        private StringGuid guid;
+
+        public long FileIdentifier => fileIdentifier;
+
+        [SerializeField]
+        private long fileIdentifier;
+
+        public AssetId(StringGuid guid, long fileIdentifier)
+        {
+            this.guid = guid;
+            this.fileIdentifier = fileIdentifier;
+        }
+
+        public override bool Equals(object obj)
+        {
+            AssetId assetId = obj as AssetId;
+            if (assetId == null)
+            {
+                return false;
+            }
+
+            return this == assetId;
+        }
+
+        public override int GetHashCode()
+        {
+            Debug.Log($"{FileIdentifier} {FileIdentifier.GetHashCode()} {Guid.ToString()} {Guid.ToString().GetHashCode()}");
+            return FileIdentifier.GetHashCode() ^ Guid.ToString().GetHashCode();
+        }
+
+        public static bool operator ==(AssetId lhs, AssetId rhs)
+        {
+            if ((object)lhs == null && (object)rhs == null)
+            {
+                return true;
+            }
+            else if ((object)lhs == null && (object)rhs != null ||
+                (object)lhs != null && (object)rhs == null)
+            {
+                return false;
+            }
+
+            return (lhs.Guid.ToString() == rhs.Guid.ToString()) && (lhs.FileIdentifier == rhs.FileIdentifier);
+        }
+
+        public static bool operator !=(AssetId lhs, AssetId rhs)
+        {
+            return !(lhs == rhs);
+        }
+    }
+
     internal class AssetCacheEntry<T> where T : class
     {
-        public StringGuid AssetId;
+        [SerializeField]
+        public AssetId AssetId;
+
+        [SerializeField]
         public T Asset;
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCacheEntry.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCacheEntry.cs
@@ -11,11 +11,17 @@ namespace Microsoft.MixedReality.SpectatorView
     {
         public static AssetId Empty { get; } = new AssetId(System.Guid.Empty, -1);
 
+        /// <summary>
+        /// The Unity guid for the Asset
+        /// </summary>
         public StringGuid Guid => guid;
 
         [SerializeField]
         private StringGuid guid;
 
+        /// <summary>
+        /// The Unity file identifier for the Asset
+        /// </summary>
         public long FileIdentifier => fileIdentifier;
 
         [SerializeField]

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCacheEntry.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCacheEntry.cs
@@ -40,7 +40,6 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public override int GetHashCode()
         {
-            Debug.Log($"{FileIdentifier} {FileIdentifier.GetHashCode()} {Guid.ToString()} {Guid.ToString().GetHashCode()}");
             return FileIdentifier.GetHashCode() ^ Guid.ToString().GetHashCode();
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
@@ -85,12 +85,12 @@ namespace Microsoft.MixedReality.SpectatorView
             }
         }
 
-        public Guid GetMeshId(Mesh mesh)
+        public AssetId GetMeshId(Mesh mesh)
         {
-            return meshAssets?.GetAssetId(mesh) ?? Guid.Empty;
+            return meshAssets?.GetAssetId(mesh) ?? AssetId.Empty;
         }
 
-        public bool AttachMeshFilter(GameObject gameObject, Guid assetId)
+        public bool AttachMeshFilter(GameObject gameObject, AssetId assetId)
         {
             ComponentExtensions.EnsureComponent<MeshRenderer>(gameObject);
 
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.SpectatorView
             return false;
         }
 
-        public bool AttachSkinnedMeshRenderer(GameObject gameObject, Guid assetId)
+        public bool AttachSkinnedMeshRenderer(GameObject gameObject, AssetId assetId)
         {
             Mesh mesh = meshAssets.GetAsset(assetId);
             if (mesh != null)

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkExtensions.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkExtensions.cs
@@ -69,6 +69,19 @@ namespace Microsoft.MixedReality.SpectatorView
             message.Write(value.a);
         }
 
+        internal static void Write(this BinaryWriter message, AssetId assetId)
+        {
+            message.Write(assetId.Guid);
+            message.Write(assetId.FileIdentifier);
+        }
+
+        internal static AssetId ReadAssetId(this BinaryReader message)
+        {
+            var guid = message.ReadGuid();
+            var fileId = message.ReadInt64();
+            return new AssetId(guid, fileId);
+        }
+
         public static bool ReadBoolean(this BinaryReader message)
         {
             return message.ReadByte() != 0;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceBroadcaster.cs
@@ -26,12 +26,12 @@ namespace Microsoft.MixedReality.SpectatorView
         private float previousVolume;
         private AudioSourceProperties previousProperties;
 
-        public Guid AudioClipAssetId
+        public AssetId AudioClipAssetId
         {
             get { return AudioSourceService.Instance.GetAudioClipId(audioSource.clip); }
         }
 
-        public Guid AudioMixerGroupAssetId
+        public AssetId AudioMixerGroupAssetId
         {
             get { return AudioSourceService.Instance.GetAudioMixerGroupId(audioSource.outputAudioMixerGroup); }
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceObserver.cs
@@ -15,8 +15,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (AudioSourceBroadcaster.HasFlag(changeType, AudioSourceBroadcaster.ChangeType.Properties))
             {
-                Guid audioClipId = message.ReadGuid();
-                Guid audioMixerGroupId = message.ReadGuid();
+                AssetId audioClipId = message.ReadAssetId();
+                AssetId audioMixerGroupId = message.ReadAssetId();
 
                 attachedComponent.clip = AudioSourceService.Instance.GetAudioClip(audioClipId);
                 attachedComponent.outputAudioMixerGroup = AudioSourceService.Instance.GetAudioMixerGroup(audioMixerGroupId);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceService.cs
@@ -36,22 +36,22 @@ namespace Microsoft.MixedReality.SpectatorView
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<AudioSourceBroadcaster>(typeof(AudioSource)));
         }
 
-        public Guid GetAudioClipId(AudioClip clip)
+        public AssetId GetAudioClipId(AudioClip clip)
         {
-            return audioClipAssets?.GetAssetId(clip) ?? Guid.Empty;
+            return audioClipAssets?.GetAssetId(clip) ?? AssetId.Empty;
         }
 
-        public AudioClip GetAudioClip(Guid assetId)
+        public AudioClip GetAudioClip(AssetId assetId)
         {
             return audioClipAssets?.GetAsset(assetId);
         }
 
-        public Guid GetAudioMixerGroupId(AudioMixerGroup group)
+        public AssetId GetAudioMixerGroupId(AudioMixerGroup group)
         {
-            return audioMixerGroupAssets?.GetAssetId(group) ?? Guid.Empty;
+            return audioMixerGroupAssets?.GetAssetId(group) ?? AssetId.Empty;
         }
 
-        public AudioMixerGroup GetAudioMixerGroup(Guid assetId)
+        public AudioMixerGroup GetAudioMixerGroup(AssetId assetId)
         {
             return audioMixerGroupAssets?.GetAsset(assetId);
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Image/ImageObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Image/ImageObserver.cs
@@ -15,8 +15,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (ImageBroadcaster.HasFlag(changeType, ImageBroadcaster.ChangeType.Data))
             {
-                attachedComponent.overrideSprite = ImageService.Instance.GetSprite(message.ReadGuid());
-                attachedComponent.sprite = ImageService.Instance.GetSprite(message.ReadGuid());
+                attachedComponent.overrideSprite = ImageService.Instance.GetSprite(message.ReadAssetId());
+                attachedComponent.sprite = ImageService.Instance.GetSprite(message.ReadAssetId());
                 attachedComponent.fillAmount = message.ReadSingle();
                 attachedComponent.color = message.ReadColor();
 
@@ -55,8 +55,8 @@ namespace Microsoft.MixedReality.SpectatorView
             //Only lerp messages with data changes on its own
             if (changeType == ImageBroadcaster.ChangeType.Data)
             {
-                attachedComponent.overrideSprite = ImageService.Instance.GetSprite(message.ReadGuid());
-                attachedComponent.sprite = ImageService.Instance.GetSprite(message.ReadGuid());
+                attachedComponent.overrideSprite = ImageService.Instance.GetSprite(message.ReadAssetId());
+                attachedComponent.sprite = ImageService.Instance.GetSprite(message.ReadAssetId());
                 attachedComponent.fillAmount = Mathf.Lerp(attachedComponent.fillAmount, message.ReadSingle(), lerpVal);
                 attachedComponent.color = Color.Lerp(attachedComponent.color, message.ReadColor(), lerpVal);
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Image/ImageService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Image/ImageService.cs
@@ -36,14 +36,14 @@ namespace Microsoft.MixedReality.SpectatorView
         }
 
 
-        public Guid GetSpriteId(Sprite sprite)
+        public AssetId GetSpriteId(Sprite sprite)
         {
-            return spriteAssets?.GetAssetId(sprite) ?? Guid.Empty;
+            return spriteAssets?.GetAssetId(sprite) ?? AssetId.Empty;
         }
 
-        public Sprite GetSprite(Guid guid)
+        public Sprite GetSprite(AssetId assetId)
         {
-            return spriteAssets?.GetAsset(guid);
+            return spriteAssets?.GetAsset(assetId);
         }
 
         public void UpdateAssetCache()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterBroadcaster.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.SpectatorView
         }
 
         private MeshFilter meshFilter;
-        private Guid assetId;
+        private AssetId assetId;
 
         protected override byte InitialChangeType
         {
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
             meshFilter = GetComponent<MeshFilter>();
             assetId = AssetService.Instance.GetMeshId(meshFilter.sharedMesh);
-            if (assetId == Guid.Empty)
+            if (assetId == AssetId.Empty)
             {
                 Debug.LogError("Could not find the Mesh asset for GameObject " + this.gameObject.name + ". Check the NetworkAssetCache and ensure that you're not modifying the mesh by accessing the MeshFilter.mesh property");
             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterObserver.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             if (MeshFilterBroadcaster.HasFlag(changeType, MeshFilterBroadcaster.MeshFilterChangeType.Mesh))
             {
-                Guid assetId = message.ReadGuid();
+                AssetId assetId = message.ReadAssetId();
                 AssetService.Instance.AttachMeshFilter(this.gameObject, assetId);
             }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/SkinnedMeshRenderer/SkinnedMeshRendererBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/SkinnedMeshRenderer/SkinnedMeshRendererBroadcaster.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public bool BonesReady { get; private set;}
 
-        public Guid NetworkAssetId
+        public AssetId NetworkAssetId
         {
             get { return AssetService.Instance.GetMeshId(Renderer.sharedMesh); }
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/SkinnedMeshRenderer/SkinnedMeshRendererObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/SkinnedMeshRenderer/SkinnedMeshRendererObserver.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (SkinnedMeshRendererBroadcaster.HasFlag(changeType, SkinnedMeshRendererBroadcaster.SkinnedMeshRendererChangeType.Mesh))
             {
-                Guid networkAssetId = message.ReadGuid();
+                AssetId networkAssetId = message.ReadAssetId();
                 if (!AssetService.Instance.AttachSkinnedMeshRenderer(this.gameObject, networkAssetId))
                 {
                     Debug.Log("Missing mesh for:" + gameObject.name);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/SpriteRenderer/SpriteRendererObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/SpriteRenderer/SpriteRendererObserver.cs
@@ -15,8 +15,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (SpriteRendererBroadcaster.HasFlag(changeType, SpriteRendererBroadcaster.SpriteRendererChangeType.Sprite))
             {
-                Guid spriteGuid = message.ReadGuid();
-                Renderer.sprite = ImageService.Instance.GetSprite(spriteGuid);
+                AssetId spriteId = message.ReadAssetId();
+                Renderer.sprite = ImageService.Instance.GetSprite(spriteId);
             }
 
             if (SpriteRendererBroadcaster.HasFlag(changeType, SpriteRendererBroadcaster.SpriteRendererChangeType.Properties))

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextBroadcaster.cs
@@ -26,9 +26,9 @@ namespace Microsoft.MixedReality.SpectatorView
             MaterialProperty = 0x8
         }
 
-        public Guid FontAssetId
+        public AssetId FontAssetId
         {
-            get { return textComp.font == null ? Guid.Empty : TextService.Instance.GetFontId(textComp.font); }
+            get { return textComp.font == null ? AssetId.Empty : TextService.Instance.GetFontId(textComp.font); }
         }
 
         protected override void Awake()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextObserver.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 attachedComponent.lineSpacing = message.ReadSingle();
                 attachedComponent.horizontalOverflow = (HorizontalWrapMode)message.ReadByte();
                 attachedComponent.verticalOverflow = (VerticalWrapMode)message.ReadByte();
-                attachedComponent.font = TextService.Instance.GetFont(message.ReadGuid());
+                attachedComponent.font = TextService.Instance.GetFont(message.ReadAssetId());
             }
             if (TextBroadcaster.HasFlag(changeType, TextBroadcaster.ChangeType.Materials))
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextService.cs
@@ -27,14 +27,14 @@ namespace Microsoft.MixedReality.SpectatorView
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<TextBroadcaster>(typeof(Text)));
         }
 
-        public Guid GetFontId(Font font)
+        public AssetId GetFontId(Font font)
         {
-            return fontAssets?.GetAssetId(font) ?? Guid.Empty;
+            return fontAssets?.GetAssetId(font) ?? AssetId.Empty;
         }
 
-        public Font GetFont(Guid guid)
+        public Font GetFont(AssetId assetId)
         {
-            return fontAssets?.GetAsset(guid);
+            return fontAssets?.GetAsset(assetId);
         }
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshBroadcaster.cs
@@ -24,9 +24,9 @@ namespace Microsoft.MixedReality.SpectatorView
             get { return this.textMesh; }
         }
 
-        public Guid FontAssetId
+        public AssetId FontAssetId
         {
-            get { return TextMesh.font == null ? Guid.Empty : TextMeshService.Instance.GetFontId(TextMesh.font); }
+            get { return TextMesh.font == null ? AssetId.Empty : TextMeshService.Instance.GetFontId(TextMesh.font); }
         }
 
         protected override void OnInitialized()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshObserver.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 textMesh.offsetZ = message.ReadSingle();
                 textMesh.richText = message.ReadBoolean();
                 textMesh.tabSize = message.ReadSingle();
-                textMesh.font = TextMeshService.Instance.GetFont(message.ReadGuid());
+                textMesh.font = TextMeshService.Instance.GetFont(message.ReadAssetId());
 
                 if (textMesh.font != null)
                 {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshService.cs
@@ -26,14 +26,14 @@ namespace Microsoft.MixedReality.SpectatorView
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<TextMeshBroadcaster>(typeof(TextMesh), typeof(MeshRenderer)));
         }
 
-        public Guid GetFontId(Font font)
+        public AssetId GetFontId(Font font)
         {
-            return fontAssets?.GetAssetId(font) ?? Guid.Empty;
+            return fontAssets?.GetAssetId(font) ?? AssetId.Empty;
         }
 
-        public Font GetFont(Guid guid)
+        public Font GetFont(AssetId assetId)
         {
-            return fontAssets?.GetAsset(guid);
+            return fontAssets?.GetAsset(assetId);
         }
 
         public void UpdateAssetCache()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcasterBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcasterBase.cs
@@ -59,6 +59,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
         protected override void SendCompleteChanges(IEnumerable<SocketEndpoint> endpoints)
         {
+            previousText = this.textMesh.text;
+            previousProperties = new TextMeshProperties(textMesh);
             SendDeltaChanges(endpoints, TextMeshProBroadcasterChangeType.FontAndPlacement | TextMeshProBroadcasterChangeType.Text);
         }
 
@@ -283,7 +285,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
             public void Write(BinaryWriter message)
             {
-                message.Write(TextMeshProService.Instance.GetFontId(font));
+                AssetId fontId = TextMeshProService.Instance.GetFontId(font);
+                message.Write(fontId);
 
                 message.Write(Pack(
                     autoSizeTextContainer,

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -63,7 +63,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (HasFlag(changeType, TextMeshProBroadcasterChangeType.FontAndPlacement))
             {
-                TextMeshObserver.font = TextMeshProService.Instance.GetFont(message.ReadGuid());
+                AssetId fontId = message.ReadAssetId();
+                TextMeshObserver.font = TextMeshProService.Instance.GetFont(fontId);
 
                 bool[] values = Unpack(message.ReadByte());
                 TextMeshObserver.autoSizeTextContainer = values[0];

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProService.cs
@@ -29,14 +29,14 @@ namespace Microsoft.MixedReality.SpectatorView
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<TextMeshProBroadcaster>(typeof(TextMeshPro)));
         }
 
-        public Guid GetFontId(TMP_FontAsset font)
+        public AssetId GetFontId(TMP_FontAsset font)
         {
-            return fontAssets?.GetAssetId(font) ?? Guid.Empty;
+            return fontAssets?.GetAssetId(font) ?? AssetId.Empty;
         }
 
-        public TMP_FontAsset GetFont(Guid guid)
+        public TMP_FontAsset GetFont(AssetId assetId)
         {
-            return (TMP_FontAsset)fontAssets?.GetAsset(guid);
+            return (TMP_FontAsset)fontAssets?.GetAsset(assetId);
         }
 #endif
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StringGuid.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StringGuid.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.SpectatorView
 {
     [Serializable]
-    internal class StringGuid
+    internal class StringGuid : IComparable
     {
         [SerializeField]
         private string m_storage;
@@ -28,6 +28,22 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 return System.Guid.Empty;
             }
+        }
+
+        public override string ToString()
+        {
+            return (m_storage == null) ? System.Guid.Empty.ToString("D") : m_storage;
+        }
+
+        public int CompareTo(object obj)
+        {
+            var guid = obj as StringGuid;
+            if (guid == null)
+            {
+                return 1;
+            }
+
+            return this.m_storage.CompareTo(guid.m_storage);
         }
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/TextureAssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/TextureAssetCache.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public bool CanSerialize(Texture asset)
         {
-            return asset == null || GetAssetId(asset) != Guid.Empty;
+            return asset == null || GetAssetId(asset) != AssetId.Empty;
         }
 
         public void Serialize(BinaryWriter writer, Texture asset)
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public Texture Deserialize(BinaryReader reader)
         {
-            return GetAsset(reader.ReadGuid());
+            return GetAsset(reader.ReadAssetId());
         }
 
         protected override IEnumerable<Texture> EnumerateAllAssets()


### PR DESCRIPTION
This review addresses: https://github.com/microsoft/MixedReality-SpectatorView/issues/47. It contains the following changes:

1) A new AssetId class has been created to use as a key for AssetCacheEntries. This type contains a GUID and long is based on Asset file GUIDs and file identifiers
2) Asset caches are updated to use this new AssetId key

## Breaking Change Details:

### Notes:
StringGuid keys for asset caches have been updated to AssetIds so that they can be deterministically created on different computers. This will break old AssetCaches.

### Migration Instructions:
1. Delete asset caches in your Generated.StateSynchronization.AssetCaches\Resources folder (these will be the .asset files).
1. Call `Spectator View -> Update All Asset Caches` in your project to regenerate asset caches.
2. Recompile all player flavors (UWP, iOS, Android) of your application.