### PR TITLE
Fix text mesh text updates on android

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using System.IO;
 
 #if STATESYNC_TEXTMESHPRO
@@ -13,6 +14,8 @@ namespace Microsoft.MixedReality.SpectatorView
 {
     internal abstract class TextMeshProObserverBase : ComponentObserver
     {
+        private bool needsUpdate = false;
+
 #if STATESYNC_TEXTMESHPRO
         protected TMP_Text TextMeshObserver
         {
@@ -119,8 +122,19 @@ namespace Microsoft.MixedReality.SpectatorView
                 TextMeshObserver.verticalMapping = (TextureMappingOptions)message.ReadByte();
                 TextMeshObserver.wordWrappingRatios = message.ReadSingle();
                 TextMeshObserver.wordSpacing = message.ReadSingle();
+
+                needsUpdate = true;
             }
 #endif
+        }
+
+        protected virtual void Update()
+        {
+            if (needsUpdate)
+            {
+                TextMeshObserver.ForceMeshUpdate();
+                needsUpdate = false;
+            }
         }
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using System.IO;
 
 #if STATESYNC_TEXTMESHPRO

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -127,13 +127,17 @@ namespace Microsoft.MixedReality.SpectatorView
 #endif
         }
 
+#if STATESYNC_TEXTMESHPRO
         protected virtual void Update()
         {
             if (needsUpdate)
             {
+                // Applying a font/forcing a mesh update on the same Update pass that the TextMeshObserver is created fails to display things correctly.
+                // Therefore, we force a mesh update on the next Update pass to get things displaying correctly.
                 TextMeshObserver.ForceMeshUpdate();
                 needsUpdate = false;
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
This review addresses: https://github.com/microsoft/MixedReality-SpectatorView/issues/263

TextMeshPro content synchronization seems to be working correctly, but it appears that the first declaration of fonts for the TextMeshPro item doesn't result in the component being updated correctly. In this change we wait an update to force a text mesh component update, which gets things to appear correctly.