### PR TITLE
Add unsupported localizer list

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -19,6 +19,15 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         protected const string AppDeviceTypeLabel = "App";
         protected string holographicCameraIPAddress;
 
+        private readonly List<Guid> unsupportedLocalizers = new List<Guid>
+        {
+            ArUcoMarkerVisualSpatialLocalizer.Id,
+            ArUcoMarkerVisualDetectorSpatialLocalizer.Id,
+            QRCodeMarkerVisualSpatialLocalizer.Id,
+            QRCodeMarkerVisualDetectorSpatialLocalizer.Id,
+            new Guid("FB077E49-B855-453F-9FB5-77187B1AF784") // SpatialAnchorsLocalizer (There is no asmdef to reference for ASA)
+        };
+
         private CompositionManager cachedCompositionManager;
         private HolographicCameraObserver cachedHolographicCameraObserver;
 
@@ -180,7 +189,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 var supportedPeerLocalizers = spatialCoordinateSystemParticipant?.GetPeerSupportedLocalizersAsync();
                 if (supportedPeerLocalizers.IsCompleted)
                 {
-                    localizers = SpatialCoordinateSystemManager.Instance.Localizers.Where(localizer => supportedPeerLocalizers.Result.Contains(localizer.SpatialLocalizerId)).ToArray();
+                    localizers = SpatialCoordinateSystemManager.Instance.Localizers.Where(localizer => !unsupportedLocalizers.Contains(localizer.SpatialLocalizerId) && supportedPeerLocalizers.Result.Contains(localizer.SpatialLocalizerId)).ToArray();
                     localizerNames = localizers.Select(localizer => localizer.DisplayName).ToArray();
                     if (localizerNames.Length == 0)
                     {

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -19,6 +19,9 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         protected const string AppDeviceTypeLabel = "App";
         protected string holographicCameraIPAddress;
 
+        /// <summary>
+        /// This list contains localizers that can't be used in the compositor window for video camera filming.
+        /// </summary>
         private readonly List<Guid> unsupportedLocalizers = new List<Guid>
         {
             ArUcoMarkerVisualSpatialLocalizer.Id,
@@ -189,6 +192,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 var supportedPeerLocalizers = spatialCoordinateSystemParticipant?.GetPeerSupportedLocalizersAsync();
                 if (supportedPeerLocalizers.IsCompleted)
                 {
+                    // Only use localizers that are supported by both the device and the compositor window
                     localizers = SpatialCoordinateSystemManager.Instance.Localizers.Where(localizer => !unsupportedLocalizers.Contains(localizer.SpatialLocalizerId) && supportedPeerLocalizers.Result.Contains(localizer.SpatialLocalizerId)).ToArray();
                     localizerNames = localizers.Select(localizer => localizer.DisplayName).ToArray();
                     if (localizerNames.Length == 0)


### PR DESCRIPTION
Some changes in the current release enabled new localizers in the editor for simulation purposes. This makes for a confusing experience in the compositor window because it leads to unsupported localizers being displayed for video camera localization. This change adds an unsupported localizer list that prevents these unsupported video camera localizers from being displayed as options. In the future, we can add an extension point here for customization if customer asks arise.