### PR TITLE
Fix a warning of the unused needsUpdate field.

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -13,9 +13,9 @@ namespace Microsoft.MixedReality.SpectatorView
 {
     internal abstract class TextMeshProObserverBase : ComponentObserver
     {
+#if STATESYNC_TEXTMESHPRO
         private bool needsUpdate = false;
 
-#if STATESYNC_TEXTMESHPRO
         protected TMP_Text TextMeshObserver
         {
             get;


### PR DESCRIPTION
When importing a fresh SpectatorView pull, you'll see this warning in the Unity console because this field is only used when STATESYNC_TEXTMESHPRO is specified. Of course when you're opening things for the first time (i.e. ingesting SV for the first time) it's possible to have made this step (because adding that define is a step much later)

This just puts it guarded by the define that it's actually used in.