### PR TITLE
Add tools for assessing summed times and memory usage to Spectator View

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/StateSynchronizationPerformanceWindow.cs
@@ -110,11 +110,31 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     }
                 }
 
+                if (StateSynchronizationObserver.Instance.PerformanceSummedEventDurations != null)
+                {
+                    GUILayout.Space(defaultSpacing);
+                    RenderTitle("Summed Event Durations (ms)", Color.green);
+                    foreach (var count in StateSynchronizationObserver.Instance.PerformanceSummedEventDurations)
+                    {
+                        GUILayout.Label($"{count.Item1}:{count.Item2}");
+                    }
+                }
+
                 if (StateSynchronizationObserver.Instance.PerformanceEventCounts != null)
                 {
                     GUILayout.Space(defaultSpacing);
                     RenderTitle("Event Counts (per frame)", Color.green);
                     foreach (var count in StateSynchronizationObserver.Instance.PerformanceEventCounts)
+                    {
+                        GUILayout.Label($"{count.Item1}:{count.Item2}");
+                    }
+                }
+
+                if (StateSynchronizationObserver.Instance.PerformanceMemoryUsageEvents != null)
+                {
+                    GUILayout.Space(defaultSpacing);
+                    RenderTitle("Memory Changes (bytes)", Color.green);
+                    foreach (var count in StateSynchronizationObserver.Instance.PerformanceMemoryUsageEvents)
                     {
                         GUILayout.Label($"{count.Item1}:{count.Item2}");
                     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
@@ -21,7 +21,11 @@ namespace Microsoft.MixedReality.SpectatorView
         public static TAssetCache LoadAssetCache<TAssetCache>()
             where TAssetCache : AssetCache
         {
-            return Resources.Load<TAssetCache>(typeof(TAssetCache).Name);
+            using (StateSynchronizationPerformanceMonitor.Instance.IncrementEventDuration(typeof(TAssetCache).Name, "LoadAssetCache"))
+            using(StateSynchronizationPerformanceMonitor.Instance.MeasureEventMemoryUsage(typeof(TAssetCache).Name, "LoadAssetCache"))
+            {
+                return Resources.Load<TAssetCache>(typeof(TAssetCache).Name);
+            }
         }
 
         public static string GetAssetPath(string assetName, string assetExtension)
@@ -224,27 +228,35 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public TAsset GetAsset(AssetId assetId)
         {
-            TAssetEntry assetEntry;
-            if (LookupByAssetId.TryGetValue(assetId, out assetEntry))
+            using (StateSynchronizationPerformanceMonitor.Instance.IncrementEventDuration(this.GetType().Name, "GetAsset"))
+            using (StateSynchronizationPerformanceMonitor.Instance.MeasureEventMemoryUsage(this.GetType().Name, "GetAsset"))
             {
-                return assetEntry.Asset;
-            }
-            else
-            {
-                return default(TAsset);
+                TAssetEntry assetEntry;
+                if (LookupByAssetId.TryGetValue(assetId, out assetEntry))
+                {
+                    return assetEntry.Asset;
+                }
+                else
+                {
+                    return default(TAsset);
+                }
             }
         }
 
         public AssetId GetAssetId(TAsset asset)
         {
-            TAssetEntry assetEntry;
-            if (asset != null && LookupByAsset.TryGetValue(asset, out assetEntry))
+            using (StateSynchronizationPerformanceMonitor.Instance.IncrementEventDuration(this.GetType().Name, "GetAssetId"))
+            using (StateSynchronizationPerformanceMonitor.Instance.MeasureEventMemoryUsage(this.GetType().Name, "GetAssetId"))
             {
-                return assetEntry.AssetId;
-            }
-            else
-            {
-                return AssetId.Empty;
+                TAssetEntry assetEntry;
+                if (asset != null && LookupByAsset.TryGetValue(asset, out assetEntry))
+                {
+                    return assetEntry.AssetId;
+                }
+                else
+                {
+                    return AssetId.Empty;
+                }
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
@@ -229,7 +229,6 @@ namespace Microsoft.MixedReality.SpectatorView
         public TAsset GetAsset(AssetId assetId)
         {
             using (StateSynchronizationPerformanceMonitor.Instance.IncrementEventDuration(this.GetType().Name, "GetAsset"))
-            using (StateSynchronizationPerformanceMonitor.Instance.MeasureEventMemoryUsage(this.GetType().Name, "GetAsset"))
             {
                 TAssetEntry assetEntry;
                 if (LookupByAssetId.TryGetValue(assetId, out assetEntry))
@@ -246,7 +245,6 @@ namespace Microsoft.MixedReality.SpectatorView
         public AssetId GetAssetId(TAsset asset)
         {
             using (StateSynchronizationPerformanceMonitor.Instance.IncrementEventDuration(this.GetType().Name, "GetAssetId"))
-            using (StateSynchronizationPerformanceMonitor.Instance.MeasureEventMemoryUsage(this.GetType().Name, "GetAssetId"))
             {
                 TAssetEntry assetEntry;
                 if (asset != null && LookupByAsset.TryGetValue(asset, out assetEntry))

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetCache.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.SpectatorView
             where TAssetCache : AssetCache
         {
             using (StateSynchronizationPerformanceMonitor.Instance.IncrementEventDuration(typeof(TAssetCache).Name, "LoadAssetCache"))
-            using(StateSynchronizationPerformanceMonitor.Instance.MeasureEventMemoryUsage(typeof(TAssetCache).Name, "LoadAssetCache"))
+            using(StateSynchronizationPerformanceMonitor.Instance.MeasureEventMemoryUsage(typeof(TAssetCache).Name, "LoadingAssets"))
             {
                 return Resources.Load<TAssetCache>(typeof(TAssetCache).Name);
             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private readonly Dictionary<ShortID, IAssetSerializer<Texture>> textureSerializers = new Dictionary<ShortID, IAssetSerializer<Texture>>();
 
-        protected void Start()
+        protected virtual void Start()
         {
             textureAssets = LookupAssetCache<TextureAssetCache>();
             meshAssets = LookupAssetCache<MeshAssetCache>();

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
@@ -16,10 +16,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private readonly Dictionary<ShortID, IAssetSerializer<Texture>> textureSerializers = new Dictionary<ShortID, IAssetSerializer<Texture>>();
 
-        protected override void Awake()
+        protected void Start()
         {
-            base.Awake();
-
             textureAssets = LookupAssetCache<TextureAssetCache>();
             meshAssets = LookupAssetCache<MeshAssetCache>();
             materialPropertyAssets = LookupAssetCache<MaterialPropertyAssetCache>();

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/BroadcasterSettings.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/BroadcasterSettings.cs
@@ -24,5 +24,18 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             get { return automaticallyBroadcastAllGameObjects; }
         }
+
+
+        [SerializeField]
+        [Tooltip("Check to force performance reporting at compile time so that measures can be made on startup taken prior to connecting to the broadcaster device. Note: enabling this parameter will decrease the overall performance of the user application.")]
+        private bool forcePerformanceReporting = false;
+
+        /// <summary>
+        /// Forces performance reporting at compile time so that on start up measures can be taken prior to connecting to the broadcaster device.
+        /// </summary>
+        public bool ForcePerformanceReporting
+        {
+            get { return forcePerformanceReporting; }
+        }
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/GlobalShaderPropertiesBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/GlobalShaderPropertiesBroadcaster.cs
@@ -15,10 +15,8 @@ namespace Microsoft.MixedReality.SpectatorView
         private List<GlobalMaterialPropertyAsset> changedProperties = new List<GlobalMaterialPropertyAsset>();
         private CustomShaderPropertyAssetCache assetCache;
 
-        protected override void Awake()
+        protected void Start()
         {
-            base.Awake();
-
             assetCache = AssetCache.LoadAssetCache<CustomShaderPropertyAssetCache>();
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/GlobalShaderPropertiesBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/GlobalShaderPropertiesBroadcaster.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private List<GlobalMaterialPropertyAsset> changedProperties = new List<GlobalMaterialPropertyAsset>();
         private CustomShaderPropertyAssetCache assetCache;
 
-        protected void Start()
+        protected virtual void Start()
         {
             assetCache = AssetCache.LoadAssetCache<CustomShaderPropertyAssetCache>();
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/AudioSource/AudioSourceService.cs
@@ -23,16 +23,10 @@ namespace Microsoft.MixedReality.SpectatorView
         private AudioClipAssetCache audioClipAssets;
         private AudioMixerGroupAssetCache audioMixerGroupAssets;
 
-        protected override void Awake()
-        {
-            base.Awake();
-
-            audioClipAssets = AudioClipAssetCache.LoadAssetCache<AudioClipAssetCache>();
-            audioMixerGroupAssets = AudioMixerGroupAssetCache.LoadAssetCache<AudioMixerGroupAssetCache>();
-        }
-
         private void Start()
         {
+            audioClipAssets = AudioClipAssetCache.LoadAssetCache<AudioClipAssetCache>();
+            audioMixerGroupAssets = AudioMixerGroupAssetCache.LoadAssetCache<AudioMixerGroupAssetCache>();
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<AudioSourceBroadcaster>(typeof(AudioSource)));
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Image/ImageService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Image/ImageService.cs
@@ -16,15 +16,9 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private SpriteAssetCache spriteAssets;
 
-        protected override void Awake()
-        {
-            base.Awake();
-
-            spriteAssets = SpriteAssetCache.LoadAssetCache<SpriteAssetCache>();
-        }
-
         private void Start()
         {
+            spriteAssets = SpriteAssetCache.LoadAssetCache<SpriteAssetCache>();
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<ImageBroadcaster>(typeof(Image)));
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/Text/TextService.cs
@@ -15,15 +15,9 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private FontAssetCache fontAssets;
 
-        protected override void Awake()
-        {
-            base.Awake();
-
-            fontAssets = FontAssetCache.LoadAssetCache<FontAssetCache>();
-        }
-
         private void Start()
         {
+            fontAssets = FontAssetCache.LoadAssetCache<FontAssetCache>();
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<TextBroadcaster>(typeof(Text)));
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMesh/TextMeshService.cs
@@ -13,16 +13,10 @@ namespace Microsoft.MixedReality.SpectatorView
         public override ShortID GetID() { return ID; }
 
         private FontAssetCache fontAssets;
-
-        protected override void Awake()
-        {
-            base.Awake();
-
-            fontAssets = FontAssetCache.LoadAssetCache<FontAssetCache>();
-        }
-
+        
         private void Start()
         {
+            fontAssets = FontAssetCache.LoadAssetCache<FontAssetCache>();
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<TextMeshBroadcaster>(typeof(TextMesh), typeof(MeshRenderer)));
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProService.cs
@@ -17,15 +17,9 @@ namespace Microsoft.MixedReality.SpectatorView
 #if STATESYNC_TEXTMESHPRO
         private TextMeshProFontAssetCache fontAssets;
 
-        protected override void Awake()
-        {
-            base.Awake();
-
-            fontAssets = TextMeshProFontAssetCache.LoadAssetCache<TextMeshProFontAssetCache>();
-        }
-
         private void Start()
         {
+            fontAssets = TextMeshProFontAssetCache.LoadAssetCache<TextMeshProFontAssetCache>();
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<TextMeshProBroadcaster>(typeof(TextMeshPro)));
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationObserver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private const float heartbeatTimeInterval = 0.1f;
         private float timeSinceLastHeartbeat = 0.0f;
         private HologramSynchronizer hologramSynchronizer = new HologramSynchronizer();
-        private StateSynchronizationPerformanceMonitor.ParsedMessage lastPerfMessage = new StateSynchronizationPerformanceMonitor.ParsedMessage(false, null, null);
+        private StateSynchronizationPerformanceMonitor.ParsedMessage lastPerfMessage = StateSynchronizationPerformanceMonitor.ParsedMessage.Empty;
 
         private static readonly byte[] heartbeatMessage = GenerateHeartbeatMessage();
 
@@ -136,7 +136,9 @@ namespace Microsoft.MixedReality.SpectatorView
 
         internal bool PerformanceMonitoringModeEnabled => lastPerfMessage.PerformanceMonitoringEnabled;
         internal IReadOnlyList<Tuple<string, double>> PerformanceEventDurations => lastPerfMessage.EventDurations;
+        internal IReadOnlyList<Tuple<string, double>> PerformanceSummedEventDurations => lastPerfMessage.SummedEventDurations;
         internal IReadOnlyList<Tuple<string, int>> PerformanceEventCounts => lastPerfMessage.EventCounts;
+        internal IReadOnlyList<Tuple<string, StateSynchronizationPerformanceMonitor.MemoryUsage>> PerformanceMemoryUsageEvents => lastPerfMessage.MemoryUsages;
 
         private void CheckAndSendHeartbeat()
         {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationPerformanceMonitor.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationPerformanceMonitor.cs
@@ -302,9 +302,12 @@ namespace Microsoft.MixedReality.SpectatorView
             private long startingReservedMemory;
             private long startingUnusedMemory;
             private MemoryUsage memoryUsage;
+            private bool calculationCompleted;
 
             public MemoryScope(MemoryUsage memoryUsage)
             {
+                calculationCompleted = false;
+
                 if (!Profiler.enabled)
                 {
                     UnityEngine.Debug.LogError($"Profiler not enabled, MemoryUsage not supported.");
@@ -312,13 +315,14 @@ namespace Microsoft.MixedReality.SpectatorView
                     startingAllocatedMemory = 0;
                     startingReservedMemory = 0;
                     startingUnusedMemory = 0;
-                    return;
                 }
-
-                this.memoryUsage = memoryUsage;
-                startingAllocatedMemory = Profiler.GetTotalAllocatedMemoryLong();
-                startingReservedMemory = Profiler.GetTotalReservedMemoryLong();
-                startingUnusedMemory = Profiler.GetTotalUnusedReservedMemoryLong();
+                else
+                {
+                    this.memoryUsage = memoryUsage;
+                    startingAllocatedMemory = Profiler.GetTotalAllocatedMemoryLong();
+                    startingReservedMemory = Profiler.GetTotalReservedMemoryLong();
+                    startingUnusedMemory = Profiler.GetTotalUnusedReservedMemoryLong();
+                }
             }
 
             public void Dispose()
@@ -330,9 +334,13 @@ namespace Microsoft.MixedReality.SpectatorView
                     return;
                 }
 
-                memoryUsage.TotalAllocatedMemory += Profiler.GetTotalAllocatedMemoryLong() - startingAllocatedMemory;
-                memoryUsage.TotalReservedMemory += Profiler.GetTotalReservedMemoryLong() - startingReservedMemory;
-                memoryUsage.TotalUnusedReservedMemory += Profiler.GetTotalUnusedReservedMemoryLong() - startingUnusedMemory;
+                if (!calculationCompleted)
+                {
+                    calculationCompleted = true;
+                    memoryUsage.TotalAllocatedMemory += Profiler.GetTotalAllocatedMemoryLong() - startingAllocatedMemory;
+                    memoryUsage.TotalReservedMemory += Profiler.GetTotalReservedMemoryLong() - startingReservedMemory;
+                    memoryUsage.TotalUnusedReservedMemory += Profiler.GetTotalUnusedReservedMemoryLong() - startingUnusedMemory;
+                }
             }
         }
     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationPerformanceParameters.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/StateSynchronizationPerformanceParameters.cs
@@ -69,8 +69,20 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public static bool EnablePerformanceReporting
         {
-            get { return enablePerformanceReporting; }
-            set { enablePerformanceReporting = value; }
+            get
+            {
+                if (BroadcasterSettings.IsInitialized &&
+                    BroadcasterSettings.Instance.ForcePerformanceReporting)
+                {
+                    return true;
+                }
+
+                return enablePerformanceReporting;
+            }
+            set
+            {
+                enablePerformanceReporting = value;
+            }
         }
         private static bool enablePerformanceReporting = false;
 


### PR DESCRIPTION
We are looking to dynamically load asset bundles, which calls into question memory usage/performance around loading/using assets. This review adds some new items to the tooling for assessing performance information:

1) BroadcasterSettings now contains a flag that enables performance monitoring from Spectator View startup. This is needed to understand the time/memory associated with loading asset caches.
2) AssetCaches now load content on Start compared to on Awake. Loading on awake caused asset caches to load prior to BroadcasterSettings getting instantiated. This prevented seeing a flag that indicated whether to default to using performance reporting.
3) StateSynchronizationPerformanceMonitor now contains IncrementEventDuration. IncrementEventDuration allows developers to assess the total amount of time put towards specific events compared to assessing the average time associated with an event. This allows for viewing things like the total amount of time put towards asset loading.
4) StateSynchronizationPerformanceMonitor now contains MeasureEventMemoryUsage. This uses Unity's Performance monitor to assess changes in total allocated memory, etc over the duration of an event. This can give rough estimates for understanding how much memory is allocated when loading asset caches.