### PR TITLE
Change build name to avoid errors for iOS and fix TextMeshPro

### DIFF
--- a/samples/Build2019Demo.Unity/ProjectSettings/ProjectSettings.asset
+++ b/samples/Build2019Demo.Unity/ProjectSettings/ProjectSettings.asset
@@ -8,7 +8,7 @@ PlayerSettings:
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
   AndroidEnableSustainedPerformanceMode: 0
-  defaultScreenOrientation: 4
+  defaultScreenOrientation: 0
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
@@ -155,7 +155,7 @@ PlayerSettings:
   applicationIdentifier:
     Android: com.Microsoft.SpectatorView.Build2019Demo
     Standalone: com.Microsoft.SpectatorView.Build2019Demo
-    iOS: com.Microsoft.SpectatorView.Build2019Demo
+    iOS: com.SpectatorView.Build2019Demo
   buildNumber: {}
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 26
@@ -173,7 +173,7 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 9.0
+  iOSTargetOSVersionString: 11.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 9.0
@@ -409,7 +409,7 @@ PlayerSettings:
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
-  cameraUsageDescription: 
+  cameraUsageDescription: Camera required for AR Foundation
   locationUsageDescription: 
   microphoneUsageDescription: 
   switchNetLibKey: 
@@ -631,7 +631,8 @@ PlayerSettings:
     4: SPATIALALIGNMENT_ASA;STATESYNC_TEXTMESHPRO
     7: SPATIALALIGNMENT_ASA;STATESYNC_TEXTMESHPRO
     14: SPATIALALIGNMENT_ASA;STATESYNC_TEXTMESHPRO
-  platformArchitecture: {}
+  platformArchitecture:
+    iOS: 1
   scriptingBackend:
     Metro: 2
   il2cppCompilerConfiguration: {}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -104,7 +104,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 TextMeshObserver.fontSizeMax = message.ReadSingle();
                 TextMeshObserver.fontSizeMin = message.ReadSingle();
                 TextMeshObserver.fontStyle = (FontStyles)message.ReadInt32();
-                TextMeshObserver.fontWeight = message.ReadInt32();
+                TextMeshObserver.fontWeight = (FontWeight)message.ReadInt32();
                 TextMeshObserver.horizontalMapping = (TextureMappingOptions)message.ReadByte();
                 TextMeshObserver.lineSpacing = message.ReadSingle();
                 TextMeshObserver.lineSpacingAdjustment = message.ReadSingle();


### PR DESCRIPTION
individual developers don't seem able to use project names containing *Microsoft*. To avoid confusion/signing errors, we should remove Microsoft from our sample name.

In this review, we also move to the newest version of text mesh pro. With older versions of text mesh pro it seems that asset syncing does not work correctly for iOS.

## Breaking Change Details:

### Notes:
TextMeshPro was upgraded from 1.3.0 to 1.4.1 to fix iOS synchronization.

### Migration Instructions:
1. Open the Unity package manager (Window -> Package Manager).
2. Update TextMesh Pro dependencies from 1.3.0 to 1.4.1