### PR TITLE
Remove unnecessary monobehaviour inheritance for AndroidRecordingService and iOSRecordingService

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/ScreenRecording/AndroidRecordingService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/ScreenRecording/AndroidRecordingService.cs
@@ -9,8 +9,7 @@ namespace Microsoft.MixedReality.SpectatorView
     /// <summary>
     /// Class implementing <see cref="IRecordingService"/> for the Android platform
     /// </summary>
-    public class AndroidRecordingService : MonoBehaviour,
-    IRecordingService
+    public class AndroidRecordingService : IRecordingService
     {
         private readonly string _fileNamePrefix = "spectatorView";
         private readonly string _fileNameExt = ".mp4";

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/ScreenRecording/iOSRecordingService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/ScreenRecording/iOSRecordingService.cs
@@ -12,8 +12,7 @@ namespace Microsoft.MixedReality.SpectatorView
     /// <summary>
     /// Class implementing <see cref="IRecordingService"/> for the iOS platform
     /// </summary>
-    public class iOSRecordingService : MonoBehaviour,
-        IRecordingService
+    public class iOSRecordingService : IRecordingService
     {
         /// <inheritdoc />
         public void Dispose()


### PR DESCRIPTION
This review updates our recording services to no longer be Monobehaviours. They didn't use any MonoBehaviour functionality and the fact that they were MonoBehaviour was generating warnings at runtime when SpectatorView created them.

## Breaking Change Details

###Notes:
We are changing AndroidRecordingService and iOSRecordingService to no longer be monobehaviours based on some warnings that occurred during initialization. This may cause issues for anyone inheriting from these classes.

### Migration Instructions:
1. Convert any classes inheriting from AndroidRecordingService or iOSRecordingService to no longer be monobehaviours.
