### PR TITLE
Improve the building experience for the Spectator View Compositor Native Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,9 @@
 	path = external/Azure-Spatial-Anchors-Samples
 	url = https://github.com/Azure/azure-spatial-anchors-samples
 	ignore = dirty
+[submodule "external/gamecapture"]
+	path = external/gamecapture
+	url = https://github.com/elgatosf/gamecapture.git
+[submodule "external/vcpkg"]
+	path = external/vcpkg
+	url = https://github.com/microsoft/vcpkg.git

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
@@ -27,10 +27,30 @@ void CompositorInterface::SetFrameProvider(IFrameProvider::ProviderType type)
         frameProvider = NULL;
     }
 
+#if defined(INCLUDE_ELGATO)
     if(type == IFrameProvider::ProviderType::Elgato)
         frameProvider = new ElgatoFrameProvider();
+#endif
+
+#if defined(INCLUDE_BLACKMAGIC)
     if (type == IFrameProvider::ProviderType::BlackMagic)
         frameProvider = new DeckLinkManager();
+#endif
+}
+
+bool CompositorInterface::IsFrameProviderSupported(IFrameProvider::ProviderType providerType)
+{
+#if defined(INCLUDE_ELGATO)
+	if (providerType == IFrameProvider::ProviderType::Elgato)
+		return true;
+#endif
+
+#if defined(INCLUDE_BLACKMAGIC)
+	if (providerType == IFrameProvider::ProviderType::BlackMagic)
+		return true;
+#endif
+
+	return false;
 }
 
 bool CompositorInterface::Initialize(ID3D11Device* device, ID3D11ShaderResourceView* colorSRV, ID3D11Texture2D* outputTexture)
@@ -188,7 +208,7 @@ bool CompositorInterface::StartRecording(VideoRecordingFrameLayout frameLayout, 
 	activeVideoEncoder->StartRecording(videoPath.c_str(), ENCODE_AUDIO);
 
 	memcpy_s(lpFileName, inputFileNameLength * _WCHAR_T_SIZE, videoPath.c_str(), videoPath.size() * _WCHAR_T_SIZE);
-	*fileNameLength = videoPath.size();
+	*fileNameLength = static_cast<int>(videoPath.size());
 	return true;
 }
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
@@ -41,6 +41,7 @@ private:
 public:
     DLLEXPORT CompositorInterface();
     DLLEXPORT void SetFrameProvider(IFrameProvider::ProviderType type);
+	DLLEXPORT bool IsFrameProviderSupported(IFrameProvider::ProviderType providerType);
 
     DLLEXPORT bool Initialize(ID3D11Device* device, ID3D11ShaderResourceView* colorSRV, ID3D11Texture2D* outputTexture);
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
@@ -24,9 +24,10 @@
 ** DEALINGS IN THE SOFTWARE.
 ** -LICENSE-END-
 */
+
 #include "stdafx.h"
 
-
+#if defined(INCLUDE_BLACKMAGIC)
 #include <comutil.h>
 #include "DeckLinkDevice.h"
 
@@ -912,4 +913,4 @@ ULONG STDMETHODCALLTYPE DeckLinkDeviceDiscovery::Release(void)
 
     return newRefValue;
 }
-
+#endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-
+#if defined(INCLUDE_BLACKMAGIC)
 #include <Windows.h>
 #include <vector>
 #include "DeckLinkAPI_h.h"
@@ -166,4 +166,4 @@ public:
     virtual ULONG    STDMETHODCALLTYPE    AddRef ();
     virtual ULONG    STDMETHODCALLTYPE    Release ();
 };
-
+#endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "stdafx.h"
+
+#if defined(INCLUDE_BLACKMAGIC)
 #include "DeckLinkManager.h"
 
 
@@ -187,4 +189,4 @@ void DeckLinkManager::Dispose()
     SafeRelease(deckLinkDevice);
     SafeRelease(deckLinkDiscovery);
 }
-
+#endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#if defined(INCLUDE_BLACKMAGIC)
 #include "IFrameProvider.h"
 #include "DeckLinkDevice.h"
 
@@ -42,4 +43,5 @@ private:
     bool _useCPU;
     bool _passthroughOutput;
 };
+#endif
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DirectoryHelper.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DirectoryHelper.cpp
@@ -123,8 +123,8 @@ void DirectoryHelper::DeleteFiles(std::wstring root, std::wstring extension)
 
 BOOL DirectoryHelper::TestFileExtension(std::wstring& file, std::wstring& ext)
 {
-	int lstr = file.length();
-	int lext = ext.length();
+	auto lstr = file.length();
+	auto lext = ext.length();
 
 	if (lstr < lext)
 	{

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoFrameProvider.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoFrameProvider.cpp
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "stdafx.h"
+
+#if defined(INCLUDE_ELGATO)
 #include "ElgatoFrameProvider.h"
 
 ElgatoFrameProvider::ElgatoFrameProvider(bool useCPU) :
@@ -489,3 +491,4 @@ HRESULT ElgatoFrameProvider::IsPinDirection(IPin *pPin, PIN_DIRECTION dir, BOOL 
 }
 #pragma endregion
 
+#endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoFrameProvider.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#if defined(INCLUDE_ELGATO)
+
 #include "IFrameProvider.h"
 #include "DirectXHelper.h"
 #include "IVideoCaptureFilterTypes.h"
@@ -106,3 +108,5 @@ private:
     ElgatoSampleCallback *frameCallback = NULL;
     IElgatoVideoCaptureFilter6 *filter = NULL;
 };
+
+#endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoSampleCallback.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoSampleCallback.cpp
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "stdafx.h"
-#include "ElgatoSampleCallback.h"
 
+#if defined(INCLUDE_ELGATO)
+#include "ElgatoSampleCallback.h"
 
 ElgatoSampleCallback::ElgatoSampleCallback(ID3D11Device* device) :
     _device(device)
@@ -63,3 +64,4 @@ void ElgatoSampleCallback::UpdateSRV(ID3D11ShaderResourceView* srv, bool useCPU,
         DirectXHelper::UpdateSRV(_device, srv, srcBuffer, FRAME_WIDTH * FRAME_BPP_RGBA);
     }
 }
+#endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoSampleCallback.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoSampleCallback.h
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
+
+#if defined(INCLUDE_ELGATO)
+
 #include "qedit.h"
 #include <dshow.h>
 
@@ -86,3 +89,4 @@ private:
     bool isEnabled = false;
 };
 
+#endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -343,6 +343,16 @@ UNITYDLL int GetVideoRecordingFrameHeight(VideoRecordingFrameLayout frameLayout)
     }
 }
 
+UNITYDLL bool IsFrameProviderSupported(int providerId)
+{
+	if (ci == nullptr)
+	{
+		ci = new CompositorInterface();
+	}
+
+	return ci->IsFrameProviderSupported((IFrameProvider::ProviderType) providerId);
+}
+
 UNITYDLL bool InitializeFrameProviderOnDevice(int providerId)
 {
     if (g_outputTexture == nullptr ||

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -138,6 +138,12 @@ void UNITY_INTERFACE_API UnityPluginUnload()
     OnGraphicsDeviceEvent(kUnityGfxDeviceEventShutdown);
 
     DeleteCriticalSection(&lock);
+
+	if (ci != nullptr)
+	{
+		delete ci;
+		ci = nullptr;
+	}
 }
 
 UNITYDLL void UpdateCompositor()

--- a/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
@@ -7,11 +7,22 @@
     <!-- From: https://www.blackmagicdesign.com/support -->
     <DeckLink_inc>C:\Blackmagic DeckLink SDK 10.9.11\Win\include</DeckLink_inc>
     <!-- From: https://github.com/elgatosf/gamecapture -->
-    <Elgato_Filter Condition="$(Elgato_Filter) == ''">C:\gamecapture\VideoCaptureFilter</Elgato_Filter>
+    <Elgato_Filter Condition="$(Elgato_Filter) == ''">C:\elgatosf\gamecapture\VideoCaptureFilter</Elgato_Filter>
   </PropertyGroup>
-  <PropertyGroup />
-  <ItemDefinitionGroup />
-  <ItemGroup />
+  <ItemDefinitionGroup>
+    <ClCompile Condition="Exists('$(DeckLink_inc)') And Exists('$(Elgato_Filter)')">
+      <PreprocessorDefinitions>INCLUDE_BLACKMAGIC;INCLUDE_ELGATO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Condition="Exists('$(DeckLink_inc)') And !Exists('$(Elgato_Filter)')">
+      <PreprocessorDefinitions>INCLUDE_BLACKMAGIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Condition="!Exists('$(DeckLink_inc)') And Exists('$(Elgato_Filter)')">
+      <PreprocessorDefinitions>INCLUDE_ELGATO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Target Name="Test" BeforeTargets="PrepareForBuild">
+    <Error Condition="!Exists('$(DeckLink_inc)') And !Exists('$(Elgato_Filter)')" Text="No capture card dependencies exist for the paths defined in dependencies.props. At least one dependency must resolve to build this project."/>
+  </Target>
 </Project>
 
 <!--

--- a/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
@@ -20,7 +20,7 @@
       <PreprocessorDefinitions>INCLUDE_ELGATO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <Target Name="Test" BeforeTargets="PrepareForBuild">
+  <Target Name="TestForElgatoAndBlackmagic" BeforeTargets="PrepareForBuild">
     <Error Condition="!Exists('$(DeckLink_inc)') And !Exists('$(Elgato_Filter)')" Text="No capture card dependencies exist for the paths defined in dependencies.props. At least one dependency must resolve to build this project."/>
   </Target>
 </Project>

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using UnityEditor;
+using UnityEditor.VersionControl;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.SpectatorView.Editor
@@ -128,27 +130,47 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     RenderTitle(title, Color.green);
                 }
 
-                EditorGUILayout.BeginHorizontal("Box");
+                EditorGUILayout.BeginVertical("Box");
                 {
-                    string[] compositionOptions = new string[] { "Final composite", "Intermediate textures" };
-                    GUIContent renderingModeLabel = new GUIContent("Preview display", "Choose between displaying the composited video texture or seeing intermediate textures displayed in 4 sections (bottom left: input video, top left: opaque hologram, top right: hologram alpha mask, bottom right: hologram alpha-blended onto video)");
-                    textureRenderMode = EditorGUILayout.Popup(renderingModeLabel, textureRenderMode, compositionOptions);
-                    if (compositionManager != null && compositionManager.TextureManager != null)
+                    EditorGUILayout.Space();
+                    EditorGUILayout.BeginHorizontal();
                     {
-                        compositionManager.TextureManager.IsQuadrantVideoFrameNeededForPreviewing = textureRenderMode == (int)VideoRecordingFrameLayout.Quad;
+                        if (compositionManager != null)
+                        {
+                            GUI.enabled = compositionManager == null || !compositionManager.IsVideoFrameProviderInitialized;
+                            GUIContent label = new GUIContent("Video source", "The video capture card you want to use as input for compositing.");
+                            compositionManager.CaptureDevice = (FrameProviderDeviceType)EditorGUILayout.Popup(label, ((int)compositionManager.CaptureDevice), Enum.GetValues(typeof(FrameProviderDeviceType)).Cast<FrameProviderDeviceType>().Where(provider => compositionManager.IsFrameProviderSupported(provider) || (provider == FrameProviderDeviceType.None)).Select(x => x.ToString()).ToArray());
+                            GUI.enabled = true;
+                        }
                     }
-                    FullScreenCompositorWindow fullscreenWindow = FullScreenCompositorWindow.TryGetWindow();
-                    if (fullscreenWindow != null)
-                    {
-                        fullscreenWindow.TextureRenderMode = textureRenderMode;
-                    }
+                    EditorGUILayout.EndHorizontal();
 
-                    if (GUILayout.Button("Fullscreen", GUILayout.Width(120)))
+                    EditorGUILayout.Space();
+
+                    EditorGUILayout.BeginHorizontal();
                     {
-                        FullScreenCompositorWindow.ShowFullscreen();
+                        string[] compositionOptions = new string[] { "Final composite", "Intermediate textures" };
+                        GUIContent renderingModeLabel = new GUIContent("Preview display", "Choose between displaying the composited video texture or seeing intermediate textures displayed in 4 sections (bottom left: input video, top left: opaque hologram, top right: hologram alpha mask, bottom right: hologram alpha-blended onto video)");
+                        textureRenderMode = EditorGUILayout.Popup(renderingModeLabel, textureRenderMode, compositionOptions);
+                        if (compositionManager != null && compositionManager.TextureManager != null)
+                        {
+                            compositionManager.TextureManager.IsQuadrantVideoFrameNeededForPreviewing = textureRenderMode == (int)VideoRecordingFrameLayout.Quad;
+                        }
+                        FullScreenCompositorWindow fullscreenWindow = FullScreenCompositorWindow.TryGetWindow();
+                        if (fullscreenWindow != null)
+                        {
+                            fullscreenWindow.TextureRenderMode = textureRenderMode;
+                        }
+
+                        if (GUILayout.Button("Fullscreen", GUILayout.Width(120)))
+                        {
+                            FullScreenCompositorWindow.ShowFullscreen();
+                        }
                     }
+                    EditorGUILayout.EndHorizontal();
+                    EditorGUILayout.Space();
                 }
-                EditorGUILayout.EndHorizontal();
+                EditorGUILayout.EndVertical();
 
                 // Rendering
                 CompositeTextureGUI(textureRenderMode);
@@ -221,18 +243,6 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 EditorGUILayout.BeginVertical("Box");
                 {
                     CompositionManager compositionManager = GetCompositionManager();
-
-                    if (compositionManager != null)
-                    {
-                        EditorGUILayout.Space();
-
-                        GUI.enabled = compositionManager == null || !compositionManager.IsVideoFrameProviderInitialized;
-                        GUIContent label = new GUIContent("Video source", "The video capture card you want to use as input for compositing.");
-                        compositionManager.CaptureDevice = (FrameProviderDeviceType)EditorGUILayout.Popup(label, ((int)compositionManager.CaptureDevice), Enum.GetNames(typeof(FrameProviderDeviceType)));
-                        GUI.enabled = true;
-
-                        EditorGUILayout.Space();
-                    }
 
                     GUIContent alphaLabel = new GUIContent("Alpha", "The alpha value used to blend holographic content with video content. 0 will result in completely transparent holograms, 1 in completely opaque holograms.");
                     float newAlpha = EditorGUILayout.Slider(alphaLabel, this.hologramAlpha, 0, 1);

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -139,7 +139,12 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                         {
                             GUI.enabled = compositionManager == null || !compositionManager.IsVideoFrameProviderInitialized;
                             GUIContent label = new GUIContent("Video source", "The video capture card you want to use as input for compositing.");
-                            compositionManager.CaptureDevice = (FrameProviderDeviceType)EditorGUILayout.Popup(label, ((int)compositionManager.CaptureDevice), Enum.GetValues(typeof(FrameProviderDeviceType)).Cast<FrameProviderDeviceType>().Where(provider => compositionManager.IsFrameProviderSupported(provider) || (provider == FrameProviderDeviceType.None)).Select(x => x.ToString()).ToArray());
+                            compositionManager.CaptureDevice = (FrameProviderDeviceType)EditorGUILayout.Popup(label, ((int)compositionManager.CaptureDevice),
+                                Enum.GetValues(typeof(FrameProviderDeviceType))
+                                .Cast<FrameProviderDeviceType>()
+                                .Where(provider => compositionManager.IsFrameProviderSupported(provider) || (provider == FrameProviderDeviceType.None))
+                                .Select(x => x.ToString())
+                                .ToArray());
                             GUI.enabled = true;
                         }
                     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -171,7 +171,7 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 if (captureDeviceIndex == -1)
                 {
-                    captureDeviceIndex = PlayerPrefs.GetInt(nameof(CaptureDevice), (int)FrameProviderDeviceType.BlackMagic);
+                    captureDeviceIndex = PlayerPrefs.GetInt(nameof(CaptureDevice), (int)FrameProviderDeviceType.None);
                 }
                 return (FrameProviderDeviceType)captureDeviceIndex;
             }
@@ -378,6 +378,16 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             return UnityCompositorInterface.GetNumQueuedOutputFrames();
         }
+
+        /// <summary>
+        /// Returns true if the UnityCompositor dll supports the specified provider.
+        /// </summary>
+        /// <param name="providerId">provider to check</param>
+        /// <returns>Returns true if the provider is supported, otherwise false.</returns>
+        public bool IsFrameProviderSupported(FrameProviderDeviceType providerId)
+        {
+            return UnityCompositorInterface.IsFrameProviderSupported(providerId);
+        }
 #endif
 
         /// <summary>
@@ -481,12 +491,19 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (!isVideoFrameProviderInitialized)
             {
-                isVideoFrameProviderInitialized = UnityCompositorInterface.InitializeFrameProviderOnDevice(CaptureDevice);
-                if (isVideoFrameProviderInitialized)
+                if (UnityCompositorInterface.IsFrameProviderSupported(CaptureDevice))
                 {
-                    CurrentCompositeFrame = 0;
-                    timeSynchronizer.Reset();
-                    poseCache.Reset();
+                    isVideoFrameProviderInitialized = UnityCompositorInterface.InitializeFrameProviderOnDevice(CaptureDevice);
+                    if (isVideoFrameProviderInitialized)
+                    {
+                        CurrentCompositeFrame = 0;
+                        timeSynchronizer.Reset();
+                        poseCache.Reset();
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning($"The current capture device, {CaptureDevice}, is not supported by your build of SpectatorView.Compositor.UnityPlugin.dll.");
                 }
             }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Microsoft.MixedReality.SpectatorView
 {
-    public enum FrameProviderDeviceType : int { BlackMagic = 0, Elgato = 1 };
+    public enum FrameProviderDeviceType : int { BlackMagic = 0, Elgato = 1, None = 2 };
     public enum VideoRecordingFrameLayout : int { Composite = 0, Quad = 1 };
 
 #if UNITY_EDITOR
@@ -77,7 +77,10 @@ namespace Microsoft.MixedReality.SpectatorView
 
         [DllImport(CompositorPluginDll)]
         public static extern void StopRecording();
-        
+
+        [DllImport(CompositorPluginDll)]
+        public static extern bool IsFrameProviderSupported([MarshalAs(UnmanagedType.I4)] FrameProviderDeviceType providerId);
+
         [DllImport(CompositorPluginDll)]
         public static extern bool InitializeFrameProviderOnDevice([MarshalAs(UnmanagedType.I4)] FrameProviderDeviceType providerId);
 

--- a/tools/ci/scripts/buildNativeProjectLocal.bat
+++ b/tools/ci/scripts/buildNativeProjectLocal.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 SETLOCAL
 SET PowerShellScriptPath=%~dpn0.ps1
-PowerShell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' %1 %2;exit $LASTEXITCODE"
+PowerShell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' %1 %2 %3;exit $LASTEXITCODE"

--- a/tools/ci/scripts/buildNativeProjectLocal.ps1
+++ b/tools/ci/scripts/buildNativeProjectLocal.ps1
@@ -1,6 +1,7 @@
 param(
     $MSBuild,
     [switch]$ForceRebuild,
+    [switch]$ExcludeBlackmagic,
     [Parameter(Mandatory=$false)][ref]$Succeeded
 )
 
@@ -30,9 +31,18 @@ $86Result = "False"
 $64Result = "False"
 $CopyResult = "False"
 
-if ($ForceRebuild)
+$Arg1 = "-None"
+if ($ForceRebuild -And $ExcludeBlackmagic)
+{
+    . $PSScriptRoot\setupNativeProject.ps1 -ForceRebuild -ExcludeBlackmagic -Succeeded ([ref]$SetupResult)
+}
+elseif ($ForceRebuild)
 {
     . $PSScriptRoot\setupNativeProject.ps1 -ForceRebuild -Succeeded ([ref]$SetupResult)
+}
+elseif ($ExcludeBlackmagic)
+{
+    . $PSScriptRoot\setupNativeProject.ps1 -ExcludeBlackmagic -Succeeded ([ref]$SetupResult)
 }
 else
 {

--- a/tools/ci/scripts/dependencies.props
+++ b/tools/ci/scripts/dependencies.props
@@ -9,9 +9,20 @@
     <!-- From: https://github.com/elgatosf/gamecapture -->
     <Elgato_Filter Condition="$(Elgato_Filter) == ''">..\..\..\..\external\gamecapture\VideoCaptureFilter</Elgato_Filter>
   </PropertyGroup>
-  <PropertyGroup />
-  <ItemDefinitionGroup />
-  <ItemGroup />
+  <ItemDefinitionGroup>
+    <ClCompile Condition="Exists('$(DeckLink_inc)') And Exists('$(Elgato_Filter)')">
+      <PreprocessorDefinitions>INCLUDE_BLACKMAGIC;INCLUDE_ELGATO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Condition="Exists('$(DeckLink_inc)') And !Exists('$(Elgato_Filter)')">
+      <PreprocessorDefinitions>INCLUDE_BLACKMAGIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Condition="!Exists('$(DeckLink_inc)') And Exists('$(Elgato_Filter)')">
+      <PreprocessorDefinitions>INCLUDE_ELGATO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Target Name="Test" BeforeTargets="PrepareForBuild">
+    <Error Condition="!Exists('$(DeckLink_inc)') And !Exists('$(Elgato_Filter)')" Text="No capture card dependencies exist for the paths defined in dependencies.props. At least one dependency must resolve to build this project."/>
+  </Target>
 </Project>
 
 <!--

--- a/tools/ci/scripts/dependencies.props
+++ b/tools/ci/scripts/dependencies.props
@@ -20,7 +20,7 @@
       <PreprocessorDefinitions>INCLUDE_ELGATO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <Target Name="Test" BeforeTargets="PrepareForBuild">
+  <Target Name="TestForElgatoAndBlackmagic" BeforeTargets="PrepareForBuild">
     <Error Condition="!Exists('$(DeckLink_inc)') And !Exists('$(Elgato_Filter)')" Text="No capture card dependencies exist for the paths defined in dependencies.props. At least one dependency must resolve to build this project."/>
   </Target>
 </Project>

--- a/tools/ci/scripts/setupNativeProject.ps1
+++ b/tools/ci/scripts/setupNativeProject.ps1
@@ -4,6 +4,7 @@
 param(
     [switch]$ForceRebuild,
     [switch]$NoDownloads,
+    [switch]$ExcludeBlackmagic,
     [Parameter(Mandatory=$false)][ref]$Succeeded
 )
 
@@ -11,7 +12,11 @@ Import-Module $PSScriptRoot\spectatorViewHelpers.psm1
 
 Write-Host "Setting up Blackmagic design dependencies"
 $BlackMagicResult = "False"
-if ($NoDownloads)
+if ($ExcludeBlackmagic)
+{
+    $BlackmagicResult = $true
+}
+elseif ($NoDownloads)
 {
     SetupExternalDownloads -NoDownloads -Succeeded ([ref]$BlackMagicResult)
 }


### PR DESCRIPTION
Most users likely won't have both an elgato capture card and a blackmagic capture card. However, our current codebase requires obtaining dependencies to build for both solutions. Without a blackmagic capture card you won't have a device serial number required for getting the developer sdk. Therefore, we should make our native project friendlier to users that only have one capture card. This review contains the following changes:

1) Blackmagic and elgato frame provider code is now hidden behind INCLUDE_BLACKMAGIC and INCLUDE_ELGATO preprocessor definitions.
2) dependencies.props now enables the INCLUDE_BLACKMAGIC and INCLUDE_ELGATO preprocessor definitions based on whether the user has provided valid paths for the capture card.
3) If no capture card dependency has been provided, an error is generated during the prebuild setup based on a target added to the dependencies.props files.
4) Our scripts for building native plugins locally have been updated to not require blackmagic sdks.
5) Submodule dependencies have been added for the elgato and vcpkg projects. Both projects are mit license.
6) The compositor now exposes to the unity editor what capture cards are supported by the compiled dll. This should help decrease confusion if the dll is miscompiled for the users desired setup.

## Breaking Change Details

### Notes:
This is a minimal breaking change. Unless someone had written their own compositor ui interface, noone should need to update their own code. However, this change exposes a new function that the unity editor compositor needs, so a recompile of the compositor dll is needed.

### Migration Instructions:
1. Recompile SpectatorView.Compositor.dll and SpectatorView.Compositor.UnityPlugin.dll and readd them to your Unity project.