### PR TITLE
Add msbuildforunity to source project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 	path = external/Azure-Spatial-Anchors-Samples
 	url = https://github.com/Azure/azure-spatial-anchors-samples
 	ignore = dirty
+[submodule "external/MSBuildForUnity"]
+	path = external/MSBuildForUnity
+	url = https://github.com/microsoft/MSBuildForUnity.git

--- a/src/SpectatorView.Unity/.gitignore
+++ b/src/SpectatorView.Unity/.gitignore
@@ -91,3 +91,16 @@ Assets/android-logos.meta
 Assets/android-logos/
 Assets/logos.meta
 Assets/logos/
+
+# Custom MSBuildForUnity Project Related ignore entries
+/MSBuild/*
+!/MSBuild/Publish/
+!/MSBuild/settings.json
+/MSBuild/Publish/**/*.dll
+/MSBuild/Publish/**/*.pdb
+/MSBuildForUnity.Common.props
+/Assets/Dependencies
+/Assets/Dependencies.meta
+
+# Custom MSBuildForUnity NuGet generation entries
+NuGet/*

--- a/src/SpectatorView.Unity/Assets/Assembly-CSharp.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/Assembly-CSharp.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c509423694422be4d98088ad73b48cf9
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Assembly-CSharp.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/Dependencies.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/Dependencies.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1edf133d185a12b4f9c618bbacb60178
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Dependencies.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/PhotoCapture/Microsoft.MixedReality.PhotoCapture.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/PhotoCapture/Microsoft.MixedReality.PhotoCapture.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ef3a3e4df5c774c4db3673795871a675
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.PhotoCapture.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment/Microsoft.MixedReality.SpatialAlignment.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment/Microsoft.MixedReality.SpatialAlignment.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5fc4456d17139e84884c9a4b1846922c
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpatialAlignment.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Microsoft.MixedReality.SpectatorView.Editor.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Microsoft.MixedReality.SpectatorView.Editor.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4b501c7d85e744545be6c03b5f28e27b
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpectatorView.Editor.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Tests/Microsoft.MixedReality.SpectatorView.Tests.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Tests/Microsoft.MixedReality.SpectatorView.Tests.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7945d97ef1f124540a56f8cf48a62b75
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpectatorView.Tests.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Microsoft.MixedReality.SpectatorView.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Microsoft.MixedReality.SpectatorView.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8dd57a421f61b42428a11a07ed91dafe
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpectatorView.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorViewUnity.msb4u.sln.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorViewUnity.msb4u.sln.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9ae0a811752accd428a44fe93fb5860f
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: SpectatorViewUnity.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/MSBuild/settings.json
+++ b/src/SpectatorView.Unity/MSBuild/settings.json
@@ -1,0 +1,1 @@
+{"autoGenerateEnabled":true}

--- a/src/SpectatorView.Unity/Packages/manifest.json
+++ b/src/SpectatorView.Unity/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.microsoft.msbuildforunity": "file:../../../external/MSBuildForUnity/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity",
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.2.2",
     "com.unity.collab-proxy": "1.2.15",


### PR DESCRIPTION
This review adds msbuildforunity as a submodule of the spectator view repo, we then reference msbuildforunity as a upm package for our spectatorview.unity src project.

This is an initial staging change to start cleaning up dependencies, etc.