### PR TITLE
Remove text mesh pro preprocessor directive

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 	path = external/Azure-Spatial-Anchors-Samples
 	url = https://github.com/Azure/azure-spatial-anchors-samples
 	ignore = dirty
+[submodule "external/MSBuildForUnity"]
+	path = external/MSBuildForUnity
+	url = https://github.com/microsoft/MSBuildForUnity.git

--- a/samples/Build2019Demo.Unity/ProjectSettings/ProjectSettings.asset
+++ b/samples/Build2019Demo.Unity/ProjectSettings/ProjectSettings.asset
@@ -627,21 +627,24 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   scriptingDefineSymbols:
-    1: SPATIALALIGNMENT_ASA;STATESYNC_TEXTMESHPRO
-    4: SPATIALALIGNMENT_ASA;STATESYNC_TEXTMESHPRO
-    7: SPATIALALIGNMENT_ASA;STATESYNC_TEXTMESHPRO
-    14: SPATIALALIGNMENT_ASA;STATESYNC_TEXTMESHPRO
+    1: SPATIALALIGNMENT_ASA
+    4: SPATIALALIGNMENT_ASA
+    7: SPATIALALIGNMENT_ASA
+    14: SPATIALALIGNMENT_ASA
   platformArchitecture:
     iOS: 1
   scriptingBackend:
-    Metro: 2
+    Android: 1
+    Metro: 1
+    Standalone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
   allowUnsafeCode: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
-  apiCompatibilityLevelPerPlatform: {}
+  apiCompatibilityLevelPerPlatform:
+    Android: 3
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: SpectatorView.Build2019Demo

--- a/samples/SpectatorView.Example.Unity/Packages/manifest.json
+++ b/samples/SpectatorView.Example.Unity/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.collab-proxy": "1.2.15",
     "com.unity.package-manager-ui": "2.0.7",
     "com.unity.purchasing": "2.0.3",
-    "com.unity.textmeshpro": "1.3.0",
+    "com.unity.textmeshpro": "1.4.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/src/SpectatorView.Unity/.gitignore
+++ b/src/SpectatorView.Unity/.gitignore
@@ -91,3 +91,16 @@ Assets/android-logos.meta
 Assets/android-logos/
 Assets/logos.meta
 Assets/logos/
+
+# Custom MSBuildForUnity Project Related ignore entries
+/MSBuild/*
+!/MSBuild/Publish/
+!/MSBuild/settings.json
+/MSBuild/Publish/**/*.dll
+/MSBuild/Publish/**/*.pdb
+/MSBuildForUnity.Common.props
+/Assets/Dependencies
+/Assets/Dependencies.meta
+
+# Custom MSBuildForUnity NuGet generation entries
+NuGet/*

--- a/src/SpectatorView.Unity/Assets/Assembly-CSharp.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/Assembly-CSharp.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c509423694422be4d98088ad73b48cf9
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Assembly-CSharp.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/Dependencies.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/Dependencies.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1edf133d185a12b4f9c618bbacb60178
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Dependencies.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/PhotoCapture/Microsoft.MixedReality.PhotoCapture.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/PhotoCapture/Microsoft.MixedReality.PhotoCapture.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ef3a3e4df5c774c4db3673795871a675
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.PhotoCapture.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpatialAlignment/Microsoft.MixedReality.SpatialAlignment.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpatialAlignment/Microsoft.MixedReality.SpatialAlignment.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5fc4456d17139e84884c9a4b1846922c
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpatialAlignment.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Microsoft.MixedReality.SpectatorView.Editor.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Microsoft.MixedReality.SpectatorView.Editor.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4b501c7d85e744545be6c03b5f28e27b
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpectatorView.Editor.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Tests/Microsoft.MixedReality.SpectatorView.Tests.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Tests/Microsoft.MixedReality.SpectatorView.Tests.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7945d97ef1f124540a56f8cf48a62b75
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpectatorView.Tests.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Microsoft.MixedReality.SpectatorView.msb4u.csproj.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Microsoft.MixedReality.SpectatorView.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8dd57a421f61b42428a11a07ed91dafe
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: Microsoft.MixedReality.SpectatorView.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcaster.cs
@@ -5,7 +5,6 @@ namespace Microsoft.MixedReality.SpectatorView
 {
     internal class TextMeshProBroadcaster : TextMeshProBroadcasterBase<TextMeshProService>
     {
-#if STATESYNC_TEXTMESHPRO
         protected override void Awake()
         {
             base.Awake();
@@ -18,6 +17,5 @@ namespace Microsoft.MixedReality.SpectatorView
                 MeshFilterBroadcaster.enabled = false;
             }
         }
-#endif
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcasterBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcasterBase.cs
@@ -3,21 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-
-#if STATESYNC_TEXTMESHPRO
 using System.IO;
 using TMPro;
 using UnityEngine;
-#endif
 
 namespace Microsoft.MixedReality.SpectatorView
 {
     internal abstract class TextMeshProBroadcasterBase<TComponentService> : ComponentBroadcaster<TComponentService, TextMeshProBroadcasterChangeType>
         where TComponentService : Singleton<TComponentService>, IComponentBroadcasterService
     {
-
-#if STATESYNC_TEXTMESHPRO
-
         private TMP_Text textMesh;
         private string previousText;
         private TextMeshProperties previousProperties;
@@ -343,26 +337,5 @@ namespace Microsoft.MixedReality.SpectatorView
                 message.Write(wordSpacing);
             }
         }
-#else
-        protected override bool HasChanges(TextMeshProBroadcasterChangeType changeFlags)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override TextMeshProBroadcasterChangeType CalculateDeltaChanges()
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override void SendCompleteChanges(IEnumerable<INetworkConnection> connections)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override void SendDeltaChanges(IEnumerable<INetworkConnection> connections, TextMeshProBroadcasterChangeType changeFlags)
-        {
-            throw new NotImplementedException();
-        }
-#endif
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcasterBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProBroadcasterBase.cs
@@ -75,8 +75,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 WriteText(changeFlags, message);
 
                 message.Flush();
-                var data = memoryStream.ToArray();
-                StateSynchronizationSceneManager.Instance.Send(connections, ref data);
+                StateSynchronizationSceneManager.Instance.Send(connections, memoryStream.GetBuffer(), 0, memoryStream.Position);
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProFontAssetCache.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProFontAssetCache.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         protected override IEnumerable<ScriptableObject> EnumerateAllAssets()
         {
-#if UNITY_EDITOR && STATESYNC_TEXTMESHPRO
+#if UNITY_EDITOR
             return EnumerateAllAssetsInAssetDatabase<TMPro.TMP_FontAsset>(IsAssetFileExtension);
 #else
             yield break;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserver.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if STATESYNC_TEXTMESHPRO
 using System;
 using TMPro;
-#endif
 
 namespace Microsoft.MixedReality.SpectatorView
 {
@@ -12,16 +10,12 @@ namespace Microsoft.MixedReality.SpectatorView
     {
         protected override void EnsureTextComponent()
         {
-#if STATESYNC_TEXTMESHPRO
             if (TextMeshObserver == null)
             {
                 TextMeshObserver = ComponentExtensions.EnsureComponent<TextMeshPro>(gameObject);
             }
-#endif
         }
 
-#if STATESYNC_TEXTMESHPRO
         public override Type ComponentType => typeof(TextMeshPro);
-#endif
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProObserverBase.cs
@@ -2,18 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.IO;
-
-#if STATESYNC_TEXTMESHPRO
 using TMPro;
-#else
-using System;
-#endif
 
 namespace Microsoft.MixedReality.SpectatorView
 {
     internal abstract class TextMeshProObserverBase : ComponentObserver
     {
-#if STATESYNC_TEXTMESHPRO
         private bool needsUpdate = false;
 
         protected TMP_Text TextMeshObserver
@@ -21,15 +15,6 @@ namespace Microsoft.MixedReality.SpectatorView
             get;
             set;
         }
-#else
-        public override Type ComponentType
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
-#endif
 
         public static bool HasFlag(TextMeshProBroadcasterChangeType changeType, TextMeshProBroadcasterChangeType flag)
         {
@@ -53,7 +38,6 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public override void Read(INetworkConnection connection, BinaryReader message)
         {
-#if STATESYNC_TEXTMESHPRO
             EnsureTextComponent();
 
             TextMeshProBroadcasterChangeType changeType = (TextMeshProBroadcasterChangeType)message.ReadByte();
@@ -125,10 +109,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
                 needsUpdate = true;
             }
-#endif
         }
 
-#if STATESYNC_TEXTMESHPRO
         protected virtual void Update()
         {
             if (needsUpdate)
@@ -139,6 +121,5 @@ namespace Microsoft.MixedReality.SpectatorView
                 needsUpdate = false;
             }
         }
-#endif
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProService.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if STATESYNC_TEXTMESHPRO
 using System;
 using TMPro;
-#endif
 
 namespace Microsoft.MixedReality.SpectatorView
 {
@@ -14,7 +12,6 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public override ShortID GetID() { return ID; }
 
-#if STATESYNC_TEXTMESHPRO
         private TextMeshProFontAssetCache fontAssets;
 
         private void Start()
@@ -32,7 +29,6 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             return (TMP_FontAsset)fontAssets?.GetAsset(assetId);
         }
-#endif
 
         public void UpdateAssetCache()
         {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProUGUIObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProUGUIObserver.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if STATESYNC_TEXTMESHPRO
 using System;
 using TMPro;
 using UnityEngine;
-#endif
 
 namespace Microsoft.MixedReality.SpectatorView
 {
@@ -13,7 +11,6 @@ namespace Microsoft.MixedReality.SpectatorView
     {
         protected override void EnsureTextComponent()
         {
-#if STATESYNC_TEXTMESHPRO
             if (TextMeshObserver == null)
             {
                 RectTransformBroadcaster srt = new RectTransformBroadcaster();
@@ -22,11 +19,8 @@ namespace Microsoft.MixedReality.SpectatorView
                 TextMeshObserver = ComponentExtensions.EnsureComponent<TextMeshProUGUI>(gameObject);
                 srt.Apply(rectTransform);
             }
-#endif
         }
 
-#if STATESYNC_TEXTMESHPRO
         public override Type ComponentType => typeof(TextMeshProUGUI);
-#endif
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProUGUIService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/TextMeshPro/TextMeshProUGUIService.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if STATESYNC_TEXTMESHPRO
 using TMPro;
-#endif
 
 namespace Microsoft.MixedReality.SpectatorView
 {
@@ -13,11 +11,9 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public override ShortID GetID() { return ID; }
 
-#if STATESYNC_TEXTMESHPRO
         private void Start()
         {
             StateSynchronizationSceneManager.Instance.RegisterService(this, new ComponentBroadcasterDefinition<TextMeshProUGUIBroadcaster>(typeof(TextMeshProUGUI)));
         }
-#endif
     }
 }

--- a/src/SpectatorView.Unity/Assets/SpectatorViewUnity.msb4u.sln.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorViewUnity.msb4u.sln.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9ae0a811752accd428a44fe93fb5860f
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: SpectatorViewUnity.msb4u
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/SpectatorView.Unity/MSBuild/settings.json
+++ b/src/SpectatorView.Unity/MSBuild/settings.json
@@ -1,0 +1,1 @@
+{"autoGenerateEnabled":true}

--- a/src/SpectatorView.Unity/Packages/manifest.json
+++ b/src/SpectatorView.Unity/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.microsoft.msbuildforunity": "file:../../../external/MSBuildForUnity/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity",
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.2.2",
     "com.unity.collab-proxy": "1.2.15",


### PR DESCRIPTION
Having different compiled binaries that support text mesh pro vs don't support text mesh pro seems like overkill. For now, we can remove the text mesh pro pre processor directive to ease our compiled unity binary setup process. This should make our automation/nuget setup simpler for binary distribution of spectator view logic.