### PR TITLE
Fix qr codes for mac

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/QRCode/QRCodeMarkerDetector.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/QRCode/QRCodeMarkerDetector.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if WINDOWS_UWP && UNITY_WSA
+#if WINDOWS_UWP && UNITY_WSA && !UNITY_EDITOR_OSX
 #define ENABLE_QRCODES
 #endif
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/QRCode/QRCodesManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/QRCode/QRCodesManager.cs
@@ -5,7 +5,7 @@
 // identity 'System.Numerics.Vectors, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Numerics.Vectors', you may need to supply runtime policy
 #pragma warning disable 1701
 
-#if UNITY_EDITOR || UNITY_WSA
+#if UNITY_EDITOR_WIN || UNITY_WSA
 using Microsoft.MixedReality.QR;
 using Microsoft.MixedReality.SpatialAlignment;
 using System;


### PR DESCRIPTION
The release we are using for qrcodes doesn't appear to be a valid zip file on mac. This causes some build errors. We don't build hololens applications on Mac, so excluding the marker detector on mac makes sense to unblock iOS builds.