### PR TITLE
Fix build break and exception in the HolographicCamera app

### DIFF
--- a/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/CalibrationDataProvider.cs
+++ b/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/CalibrationDataProvider.cs
@@ -60,7 +60,8 @@ namespace Microsoft.MixedReality.SpectatorView
                     message.Write("CalibrationData");
                     message.Write(contents.Length);
                     message.Write(contents);
-                    networkManager.Broadcast(memoryStream.ToArray());
+                    var packet = memoryStream.ToArray();
+                    networkManager.Broadcast(packet, 0, packet.LongLength);
                 }
             }
         }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/ArUcoMarkerDetector.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/ArUcoMarkerDetector.cs
@@ -177,7 +177,11 @@ namespace Microsoft.MixedReality.SpectatorView
         public void SetMarkerSize(float size)
         {
             _markerSize = size;
-            _api.SetMarkerSize(size);
+
+            if (_api != null)
+            {
+                _api.SetMarkerSize(size);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This fixes a build break in the HolographicCamera.Unity app from recent netwroking changes, and makes sure the ArUco marker detector supports SetMarker being called before it's enabled.