### PR TITLE
Add color correction to the compositor for the camera stream

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ColorCorrection
+  m_Shader: {fileID: 4800000, guid: fd14a350c1446084087e4b6628a34472, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4a864802a0091c4180d54ea8d4d655c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -28,6 +28,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
         private bool compositorStatsFoldout;
         private bool recordingFoldout;
+        private bool colorCorrectionFoldout;
         private bool hologramSettingsFoldout;
 
         private float hologramAlpha;
@@ -74,6 +75,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 NetworkConnectionGUI();
                 CompositeGUI();
                 RecordingGUI();
+                ColorCorrectionGUI();
                 HologramSettingsGUI();
                 CompositorStatsGUI();
             }
@@ -236,6 +238,120 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     }
                 }
                 EditorGUILayout.EndVertical();
+            }
+        }
+
+        private void ColorCorrectionGUI()
+        {
+            colorCorrectionFoldout = EditorGUILayout.Foldout(colorCorrectionFoldout, "Color Correction Settings");
+            if (colorCorrectionFoldout)
+            {
+                RenderTitle("Video Camera Color Correction", Color.clear);
+                CompositionManager compositionManager = GetCompositionManager();
+                bool running = compositionManager != null && compositionManager.TextureManager != null && compositionManager.TextureManager.videoFeedColorCorrection != null;
+                if (running)
+                {
+                    EditorGUILayout.BeginVertical("Box");
+                    {
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Enabled");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Enabled = EditorGUILayout.Toggle(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Enabled);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        if (GUI.enabled &&
+                            !compositionManager.TextureManager.videoFeedColorCorrection.Enabled)
+                        {
+                            GUI.enabled = false;
+                        }
+
+                        EditorGUILayout.Space();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("R Scale");
+                            compositionManager.TextureManager.videoFeedColorCorrection.RScale = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.RScale, 0, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("G Scale");
+                            compositionManager.TextureManager.videoFeedColorCorrection.GScale = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.GScale, 0, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("B Scale");
+                            compositionManager.TextureManager.videoFeedColorCorrection.BScale = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.BScale, 0, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+
+                        EditorGUILayout.Space();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("H Offset");
+                            compositionManager.TextureManager.videoFeedColorCorrection.HOffset = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.HOffset, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("S Offset");
+                            compositionManager.TextureManager.videoFeedColorCorrection.SOffset = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.SOffset, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("V Offset");
+                            compositionManager.TextureManager.videoFeedColorCorrection.VOffset = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.VOffset, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+
+                        EditorGUILayout.Space();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Brightness");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Brightness = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Brightness, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Contrast");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Contrast = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Contrast, 0, 2);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Gamma");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Gamma = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Gamma, 0.1f, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                    }
+                    EditorGUILayout.EndVertical();
+                }
+                else
+                {
+                    RenderTitle("Updating color correction is not possible when the compositor isn't running.", Color.green);
+                }
+                GUI.enabled = true;
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader
@@ -1,0 +1,94 @@
+﻿Shader "SV/ColorCorrection"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+			float _RScale;
+			float _GScale;
+			float _BScale;
+			float _HOffset;
+			float _SOffset;
+			float _VOffset;
+			float _Brightness;
+			float _Contrast;
+			float _Gamma;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+			float3 RGBToHSV(float3 rgb)
+			{
+				float epsilon = 1e-10;
+				float4 P = (rgb.g < rgb.b) ? float4(rgb.bg, -1.0, 2.0 / 3.0) : float4(rgb.gb, 0.0, -1.0 / 3.0);
+				float4 Q = (rgb.r < P.x) ? float4(P.xyw, rgb.r) : float4(rgb.r, P.yzx);
+				float C = Q.x - min(Q.w, Q.y);
+				float H = abs((Q.w - Q.y) / (6 * C + epsilon) + Q.z);
+				return float3(H, C / (Q.x + epsilon), Q.x);
+			}
+
+			float3 HSVToRGB(float3 hsv)
+			{
+				float R = abs(hsv.x * 6 - 3) - 1;
+				float G = 2 - abs(hsv.x * 6 - 2);
+				float B = 2 - abs(hsv.x * 6 - 4);
+				return ((saturate(float3(R, G, B)) - 1) * hsv.y + 1) * hsv.z;
+			}
+
+			float4 ColorCorrect(float4 input, float3 rgbScale, float3 hsvOffs, float brightness, float contrast, float gamma)
+			{
+				input.rgb *= rgbScale;
+
+				float3 hsv = RGBToHSV(input.rgb);
+				if (hsvOffs.x < 0.0f) hsvOffs.x += 2.0f;
+				hsv += hsvOffs;
+				hsv.x = fmod(hsv.x, 1.0f);
+				hsv = saturate(hsv);	// Prevent illegal colors
+
+				input.rgb = HSVToRGB(hsv);
+				input.rgb = contrast * (pow(input.rgb, 1.0f / gamma) - 0.5f) + 0.5f + brightness;
+
+				return input;
+			}
+
+            float4 frag (v2f i) : SV_Target
+            {
+                float4 col = tex2D(_MainTex, i.uv);
+                return ColorCorrect(col, float3(_RScale, _GScale, _BScale), float3(_HOffset, _SOffset, _VOffset), _Brightness, _Contrast, _Gamma);
+            }
+            ENDCG
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fd14a350c1446084087e4b6628a34472
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -10,6 +10,104 @@ using UnityEngine.Rendering;
 
 namespace Microsoft.MixedReality.SpectatorView
 {
+    [Serializable]
+    public class ColorCorrection
+    {
+        public bool Enabled;
+
+        [Range(0, 4)]
+        public float RScale;
+
+        [Range(0, 4)]
+        public float GScale;
+
+        [Range(0, 4)]
+        public float BScale;
+
+        [Range(-1, 1)]
+        public float HOffset;
+
+        [Range(-1, 1)]
+        public float SOffset;
+
+        [Range(-1, 1)]
+        public float VOffset;
+
+        [Range(-1, 1)]
+        public float Brightness;
+
+        [Range(0, 2)]
+        public float Contrast;
+
+        [Range(0.1f, 4)]
+        public float Gamma;
+
+        public ColorCorrection(bool enabled)
+        {
+            this.Enabled = enabled;
+            this.RScale = 1;
+            this.GScale = 1;
+            this.BScale = 1;
+            this.HOffset = 0;
+            this.SOffset = 0;
+            this.VOffset = 0;
+            this.Brightness = 0;
+            this.Contrast = 1;
+            this.Gamma = 1;
+        }
+
+        public void ApplyParameters(Material material)
+        {
+            if (material != null)
+            {
+                material.SetFloat("_RScale", RScale);
+                material.SetFloat("_GScale", GScale);
+                material.SetFloat("_BScale", BScale);
+                material.SetFloat("_HOffset", HOffset);
+                material.SetFloat("_SOffset", SOffset);
+                material.SetFloat("_VOffset", VOffset);
+                material.SetFloat("_Brightness", Brightness);
+                material.SetFloat("_Contrast", Contrast);
+                material.SetFloat("_Gamma", Gamma);
+            }
+        }
+
+        public static ColorCorrection GetColorCorrection(string namePrefix)
+        {
+            ColorCorrection output = new ColorCorrection(false);
+            if (!PlayerPrefs.HasKey($"{namePrefix}.{nameof(Enabled)}"))
+            {
+                return output;
+            }
+
+            output.Enabled = PlayerPrefs.GetInt($"{namePrefix}.{nameof(Enabled)}") > 0;
+            output.RScale = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(RScale)}");
+            output.GScale = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(GScale)}");
+            output.BScale = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(BScale)}");
+            output.HOffset = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(HOffset)}");
+            output.SOffset = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(SOffset)}");
+            output.VOffset = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(VOffset)}");
+            output.Brightness = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(Brightness)}");
+            output.Contrast = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(Contrast)}");
+            output.Gamma = PlayerPrefs.GetFloat($"{namePrefix}.{nameof(Gamma)}");
+            return output;
+        }
+
+        public static void StoreColorCorrection(string namePrefix, ColorCorrection colorCorrection)
+        {
+            PlayerPrefs.SetInt($"{namePrefix}.{nameof(Enabled)}", colorCorrection.Enabled ? 1 : 0);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(RScale)}", colorCorrection.RScale);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(GScale)}", colorCorrection.GScale);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(BScale)}", colorCorrection.BScale);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(HOffset)}", colorCorrection.HOffset);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(SOffset)}", colorCorrection.SOffset);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(VOffset)}", colorCorrection.VOffset);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(Brightness)}", colorCorrection.Brightness);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(Contrast)}", colorCorrection.Contrast);
+            PlayerPrefs.SetFloat($"{namePrefix}.{nameof(Gamma)}", colorCorrection.Gamma);
+        }
+    }
+
     /// <summary>
     /// Manages the textures used for compositing holograms with video, and controls
     /// the actual composition of textures together.
@@ -27,7 +125,8 @@ namespace Microsoft.MixedReality.SpectatorView
         public bool IsQuadrantVideoFrameNeededForPreviewing { get; set; }
 
         /// <summary>
-        /// The color image texture coming from the camera, converted to RGB. The Unity camera is "cleared" to this texture
+        /// The color image texture coming from the camera, converted to RGB. The Unity camera is "cleared" to this texture.
+        /// Note: If color correction is applied to the video feed, this texture will contain the color correction.
         /// </summary>
         public RenderTexture colorRGBTexture { get; private set; }
 
@@ -93,6 +192,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public event Action TextureRenderCompleted;
 
+        public ColorCorrection videoFeedColorCorrection { get; set; }
+
         private Material ignoreAlphaMat;
         private Material BGRToRGBMat;
         private Material RGBToBGRMat;
@@ -107,6 +208,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private Material extractAlphaMat;
         private Material downsampleMat;
         private Material[] downsampleMats;
+        private Material colorCorrectionMat;
 
         private Camera spectatorViewCamera;
 
@@ -115,6 +217,9 @@ namespace Microsoft.MixedReality.SpectatorView
         private bool outputYUV;
         private bool hardwareEncodeVideo;
         private IntPtr renderEvent;
+
+        private RenderTexture videoFeedColorCorrectionTexture;
+        private const string VideoFeedColorCorrectionPlayerPrefName = "VideoFeedColorCorrection";
 
         public Material IgnoreAlphaMaterial => ignoreAlphaMat;
 
@@ -205,6 +310,9 @@ namespace Microsoft.MixedReality.SpectatorView
             quadViewMat = LoadMaterial("QuadView");
             alphaBlendMat = LoadMaterial("AlphaBlend");
             textureClearMat = LoadMaterial("TextureClear");
+            colorCorrectionMat = LoadMaterial("ColorCorrection");
+
+            videoFeedColorCorrection = ColorCorrection.GetColorCorrection(VideoFeedColorCorrectionPlayerPrefName);
 
             SetHologramShaderAlpha(Compositor.DefaultAlpha);
 
@@ -226,6 +334,11 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 outputYUV = newOutputYUV;
             }
+        }
+
+        private void OnDestroy()
+        {
+            ColorCorrection.StoreColorCorrection(VideoFeedColorCorrectionPlayerPrefName, videoFeedColorCorrection);
         }
 
         private void SetupCameraAndRenderTextures()
@@ -256,6 +369,7 @@ namespace Microsoft.MixedReality.SpectatorView
             spectatorViewCamera.targetTexture = renderTexture;
 
             colorRGBTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
+            videoFeedColorCorrectionTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
             alphaTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
             compositeTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
 
@@ -284,7 +398,18 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private void OnPreRender()
         {
-            Graphics.Blit(CurrentColorTexture, colorRGBTexture, CurrentColorMaterial);
+            if (videoFeedColorCorrection.Enabled)
+            {
+                // Apply color correction to the video feed if it is enabled
+                Graphics.Blit(CurrentColorTexture, videoFeedColorCorrectionTexture, CurrentColorMaterial);
+                videoFeedColorCorrection.ApplyParameters(colorCorrectionMat);
+                colorCorrectionMat.SetTexture("_MainTex", videoFeedColorCorrectionTexture);
+                Graphics.Blit(videoFeedColorCorrectionTexture, colorRGBTexture, colorCorrectionMat);
+            }
+            else
+            {
+                Graphics.Blit(CurrentColorTexture, colorRGBTexture, CurrentColorMaterial);
+            }
 
             if (IsVideoRecordingQuadrantMode)
             {


### PR DESCRIPTION
Add the ability to apply color correction to the video camera feed. This review contains the following changes:

1) During OnPreRender, the TextureManager now has the ability to apply color correction to the video camera frame prior to starting compositing.
2) The CompositorWindow now contains UI that allows for users to perform color correction.