### PR TITLE
Add yield to OnPostRender for spectator view compositor

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -304,6 +304,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private IEnumerator OnPostRender()
         {
+            // Wait until the end of the frame so that all rendering has completed.
+            // We need this wait in order to support post processing effects applied to the camera.
             yield return new WaitForEndOfFrame();
 
             displayOutputTexture.DiscardContents();

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -302,8 +302,10 @@ namespace Microsoft.MixedReality.SpectatorView
             }
         }
 
-        private void OnPostRender()
+        private IEnumerator OnPostRender()
         {
+            yield return new WaitForEndOfFrame();
+
             displayOutputTexture.DiscardContents();
 
             RenderTexture sourceTexture = spectatorViewCamera.targetTexture;


### PR DESCRIPTION
If we don't wait for the end of the frame, post processing effects don't work correctly.