### PR TITLE
Add the ability to manipulate min and max depth for occlusion

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
@@ -7,7 +7,7 @@
     <!-- From: https://www.blackmagicdesign.com/support -->
     <DeckLink_inc>C:\Blackmagic DeckLink SDK 10.9.11\Win\include</DeckLink_inc>
     <!-- From: https://github.com/elgatosf/gamecapture -->
-    <Elgato_Filter Condition="$(Elgato_Filter) == ''">C:\gamecapture\VideoCaptureFilter</Elgato_Filter>
+    <Elgato_Filter Condition="$(Elgato_Filter) == ''">$(SolutionDir)\..\..\external\elgatosf\gamecapture\VideoCaptureFilter</Elgato_Filter>
     
     <!-- From: https://docs.microsoft.com/en-us/azure/kinect-dk/sensor-sdk-download -->
     <AzureKinectSDK>C:\Program Files\Azure Kinect SDK v1.3.0</AzureKinectSDK>

--- a/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
@@ -13,7 +13,7 @@
     <AzureKinectSDK>C:\Program Files\Azure Kinect SDK v1.3.0</AzureKinectSDK>
 
     <!-- From: https://docs.microsoft.com/en-us/azure/kinect-dk/body-sdk-download -->
-    <AzureKinectBodyTrackingSDK>C:\Program Files\Azure Kinect Body Tracking SDK</AzureKinectBodyTrackingSDK>
+    <AzureKinectBodyTrackingSDK>C:\Program Files\Azure Kinect Body Tracking SDK 1.0.0</AzureKinectBodyTrackingSDK>
     
     <AzureKinectIncludeDirectory>$(AzureKinectSDK)\sdk\include</AzureKinectIncludeDirectory>
     <AzureKinectLibraryDirectory>$(AzureKinectSDK)\sdk\windows-desktop\amd64\release\lib</AzureKinectLibraryDirectory>
@@ -27,7 +27,7 @@
     <ClCompile Condition="Exists('$(DeckLink_inc)')">
       <PreprocessorDefinitions>INCLUDE_BLACKMAGIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <ClCompile Condition="!Exists('$(DeckLink_inc)')">
+    <ClCompile Condition="Exists('$(Elgato_Filter)')">
       <PreprocessorDefinitions>INCLUDE_ELGATO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Condition="Exists('$(AzureKinectSDK)')">

--- a/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/dependencies.props
@@ -7,7 +7,7 @@
     <!-- From: https://www.blackmagicdesign.com/support -->
     <DeckLink_inc>C:\Blackmagic DeckLink SDK 10.9.11\Win\include</DeckLink_inc>
     <!-- From: https://github.com/elgatosf/gamecapture -->
-    <Elgato_Filter Condition="$(Elgato_Filter) == ''">$(SolutionDir)\..\..\external\elgatosf\gamecapture\VideoCaptureFilter</Elgato_Filter>
+    <Elgato_Filter Condition="$(Elgato_Filter) == ''">C:\gamecapture\VideoCaptureFilter</Elgato_Filter>
     
     <!-- From: https://docs.microsoft.com/en-us/azure/kinect-dk/sensor-sdk-download -->
     <AzureKinectSDK>C:\Program Files\Azure Kinect SDK v1.3.0</AzureKinectSDK>

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/Blur.mat
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/Blur.mat
@@ -69,6 +69,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Floats:
     - _BlurIntensity: 5
+    - _BlurSize: 10
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ColorCorrection
+  m_Shader: {fileID: 4800000, guid: fd14a350c1446084087e4b6628a34472, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/ColorCorrection.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4a864802a0091c4180d54ea8d4d655c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/OcclusionMask.mat
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Resources/Materials/OcclusionMask.mat
@@ -19,7 +19,15 @@ Material:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _BodyMaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DepthTexture:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -63,7 +71,9 @@ Material:
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
+    - _MaxDepth: 10
     - _Metallic: 0
+    - _MinDepth: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -333,6 +333,14 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                                 compositionManager.TextureManager.blurSize, 0, 10);
                         }
                         EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Number of Blur Passes");
+                            compositionManager.TextureManager.numBlurPasses = (int) EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.numBlurPasses, 1, 5);
+                        }
+                        EditorGUILayout.EndHorizontal();
                     }
                     else if (compositionManager.OcclusionMode == OcclusionSetting.RawDepthCamera)
                     {
@@ -343,6 +351,14 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                             compositionManager.TextureManager.blurSize = EditorGUILayout.Slider(
                                 label,
                                 compositionManager.TextureManager.blurSize, 0, 10);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Number of Blur Passes");
+                            compositionManager.TextureManager.numBlurPasses = (int) EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.numBlurPasses, 1, 5);
                         }
                         EditorGUILayout.EndHorizontal();
                     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -345,22 +345,6 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                                 compositionManager.TextureManager.blurSize, 0, 10);
                         }
                         EditorGUILayout.EndHorizontal();
-                        EditorGUILayout.BeginHorizontal();
-                        {
-                            GUIContent label = new GUIContent("Minimum Hologram Depth");
-                            compositionManager.TextureManager.occlusionMinHologramDepth = EditorGUILayout.Slider(
-                                label,
-                                compositionManager.TextureManager.occlusionMinHologramDepth, 0, 10);
-                        }
-                        EditorGUILayout.EndHorizontal();
-                        EditorGUILayout.BeginHorizontal();
-                        {
-                            GUIContent label = new GUIContent("Maximum Occlusion Depth");
-                            compositionManager.TextureManager.occlusionMaxDepth = EditorGUILayout.Slider(
-                                label,
-                                compositionManager.TextureManager.occlusionMaxDepth, 0, 10);
-                        }
-                        EditorGUILayout.EndHorizontal();
                     }
                 }
                 else

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -30,6 +30,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         private bool recordingFoldout;
         private bool colorCorrectionFoldout;
         private bool hologramSettingsFoldout;
+        private bool occlusionSettingsFoldout;
 
         private float hologramAlpha;
 
@@ -77,6 +78,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             {
                 NetworkConnectionGUI();
                 CompositeGUI();
+                OcclusionSettingsGUI();
                 RecordingGUI();
                 ColorCorrectionGUI();
                 HologramSettingsGUI();
@@ -303,6 +305,52 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     }
                 }
                 EditorGUILayout.EndVertical();
+            }
+        }
+
+        private void OcclusionSettingsGUI()
+        {
+            occlusionSettingsFoldout = EditorGUILayout.Foldout(occlusionSettingsFoldout, "Occlusion Settings");
+            if (occlusionSettingsFoldout)
+            {
+                CompositionManager compositionManager = GetCompositionManager();
+                bool running = compositionManager != null && compositionManager.TextureManager != null && compositionManager.TextureManager.videoFeedColorCorrection != null;
+                if (running)
+                {
+                    if (!compositionManager.IsOcclusionSettingSupported(compositionManager.OcclusionMode))
+                    {
+                        RenderTitle("The current camera does not support occlusion.", Color.clear);
+                    }
+                    else if (compositionManager.OcclusionMode == OcclusionSetting.BodyTracking)
+                    {
+                        RenderTitle("Body Tracking does not currently have any configurable settings.", Color.clear);
+                    }
+                    else if (compositionManager.OcclusionMode == OcclusionSetting.RawDepthCamera)
+                    {
+                        RenderTitle("Raw Depth Camera Settings", Color.clear);
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Minimum Depth");
+                            compositionManager.TextureManager.occlusionMinDepth = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.occlusionMinDepth, 0, 10);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Maximum Depth");
+                            compositionManager.TextureManager.occlusionMaxDepth = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.occlusionMaxDepth, 0, 10);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                    }
+                }
+                else
+                {
+                    RenderTitle("Updating occlusion settings is not possible when the compositor isn't running.", Color.green);
+                }
+                GUI.enabled = true;
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -28,6 +28,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
         private bool compositorStatsFoldout;
         private bool recordingFoldout;
+        private bool colorCorrectionFoldout;
         private bool hologramSettingsFoldout;
 
         private float hologramAlpha;
@@ -77,6 +78,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 NetworkConnectionGUI();
                 CompositeGUI();
                 RecordingGUI();
+                ColorCorrectionGUI();
                 HologramSettingsGUI();
                 CompositorStatsGUI();
             }
@@ -301,6 +303,120 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     }
                 }
                 EditorGUILayout.EndVertical();
+            }
+        }
+
+        private void ColorCorrectionGUI()
+        {
+            colorCorrectionFoldout = EditorGUILayout.Foldout(colorCorrectionFoldout, "Color Correction Settings");
+            if (colorCorrectionFoldout)
+            {
+                RenderTitle("Video Camera Color Correction", Color.clear);
+                CompositionManager compositionManager = GetCompositionManager();
+                bool running = compositionManager != null && compositionManager.TextureManager != null && compositionManager.TextureManager.videoFeedColorCorrection != null;
+                if (running)
+                {
+                    EditorGUILayout.BeginVertical("Box");
+                    {
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Enabled");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Enabled = EditorGUILayout.Toggle(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Enabled);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        if (GUI.enabled &&
+                            !compositionManager.TextureManager.videoFeedColorCorrection.Enabled)
+                        {
+                            GUI.enabled = false;
+                        }
+
+                        EditorGUILayout.Space();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("R Scale");
+                            compositionManager.TextureManager.videoFeedColorCorrection.RScale = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.RScale, 0, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("G Scale");
+                            compositionManager.TextureManager.videoFeedColorCorrection.GScale = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.GScale, 0, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("B Scale");
+                            compositionManager.TextureManager.videoFeedColorCorrection.BScale = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.BScale, 0, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+
+                        EditorGUILayout.Space();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("H Offset");
+                            compositionManager.TextureManager.videoFeedColorCorrection.HOffset = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.HOffset, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("S Offset");
+                            compositionManager.TextureManager.videoFeedColorCorrection.SOffset = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.SOffset, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("V Offset");
+                            compositionManager.TextureManager.videoFeedColorCorrection.VOffset = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.VOffset, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+
+                        EditorGUILayout.Space();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Brightness");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Brightness = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Brightness, -1, 1);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Contrast");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Contrast = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Contrast, 0, 2);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUILayout.BeginHorizontal();
+                        {
+                            GUIContent label = new GUIContent("Gamma");
+                            compositionManager.TextureManager.videoFeedColorCorrection.Gamma = EditorGUILayout.Slider(
+                                label,
+                                compositionManager.TextureManager.videoFeedColorCorrection.Gamma, 0.1f, 4);
+                        }
+                        EditorGUILayout.EndHorizontal();
+                    }
+                    EditorGUILayout.EndVertical();
+                }
+                else
+                {
+                    RenderTitle("Updating color correction is not possible when the compositor isn't running.", Color.green);
+                }
+                GUI.enabled = true;
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -315,7 +315,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             if (occlusionSettingsFoldout)
             {
                 CompositionManager compositionManager = GetCompositionManager();
-                bool running = compositionManager != null && compositionManager.TextureManager != null && compositionManager.TextureManager.videoFeedColorCorrection != null;
+                bool running = compositionManager != null && compositionManager.TextureManager != null;
                 if (running)
                 {
                     if (!compositionManager.IsOcclusionSettingSupported(compositionManager.OcclusionMode))

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -52,7 +52,6 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         private const string calibrationNotLoadedMessage = "No camera calibration received";
         private const int horizontalFrameRectangleMargin = 50;
         protected const int textureRenderModeComposite = 0;
-        protected const int textureRenderModeSplit = 1;
         private const float quadPadding = 4;
         protected const int connectAndDisconnectButtonWidth = 90;
         private const int settingsButtonWidth = 24;
@@ -302,7 +301,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             return GUILayoutUtility.GetRect(frameWidth, frameHeight);
         }
 
-        protected void CompositeTextureGUI(int textureRenderMode)
+        protected void CompositeTextureGUI(PreviewTextureMode previewTextureMode)
         {
             UpdateFrameDimensions();
 
@@ -313,13 +312,17 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 CompositionManager compositionManager = GetCompositionManager();
                 if (compositionManager != null && compositionManager.TextureManager != null)
                 {
-                    if (textureRenderMode == textureRenderModeSplit)
+                    switch (previewTextureMode)
                     {
-                        Graphics.DrawTexture(framesRect, compositionManager.TextureManager.quadViewOutputTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
-                    }
-                    else
-                    {
-                        Graphics.DrawTexture(framesRect, compositionManager.TextureManager.previewTexture);
+                        case PreviewTextureMode.Composite:
+                            Graphics.DrawTexture(framesRect, compositionManager.TextureManager.previewTexture);
+                            break;
+                        case PreviewTextureMode.Quad:
+                            Graphics.DrawTexture(framesRect, compositionManager.TextureManager.quadViewOutputTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
+                            break;
+                        case PreviewTextureMode.OcclusionMask:
+                            Graphics.DrawTexture(framesRect, compositionManager.TextureManager.blurOcclusionTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
+                            break;
                     }
                 }
             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/FullScreenCompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/FullScreenCompositorWindow.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
     [Description("Compositor Preview")]
     internal class FullScreenCompositorWindow : CompositorWindowBase<FullScreenCompositorWindow>
     {
-        public int TextureRenderMode { get; set; }
+        public PreviewTextureMode PreviewTextureMode { get; set; }
 
         protected override Rect ComputeCompositeGUIRect(float frameWidth, float frameHeight)
         {
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
         private void OnGUI()
         {
-            CompositeTextureGUI(TextureRenderMode);
+            CompositeTextureGUI(PreviewTextureMode);
         }
 
 #if UNITY_EDITOR_WIN

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader
@@ -1,0 +1,94 @@
+﻿Shader "SV/ColorCorrection"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+			float _RScale;
+			float _GScale;
+			float _BScale;
+			float _HOffset;
+			float _SOffset;
+			float _VOffset;
+			float _Brightness;
+			float _Contrast;
+			float _Gamma;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+			float3 RGBToHSV(float3 rgb)
+			{
+				float epsilon = 1e-10;
+				float4 P = (rgb.g < rgb.b) ? float4(rgb.bg, -1.0, 2.0 / 3.0) : float4(rgb.gb, 0.0, -1.0 / 3.0);
+				float4 Q = (rgb.r < P.x) ? float4(P.xyw, rgb.r) : float4(rgb.r, P.yzx);
+				float C = Q.x - min(Q.w, Q.y);
+				float H = abs((Q.w - Q.y) / (6 * C + epsilon) + Q.z);
+				return float3(H, C / (Q.x + epsilon), Q.x);
+			}
+
+			float3 HSVToRGB(float3 hsv)
+			{
+				float R = abs(hsv.x * 6 - 3) - 1;
+				float G = 2 - abs(hsv.x * 6 - 2);
+				float B = 2 - abs(hsv.x * 6 - 4);
+				return ((saturate(float3(R, G, B)) - 1) * hsv.y + 1) * hsv.z;
+			}
+
+			float4 ColorCorrect(float4 input, float3 rgbScale, float3 hsvOffs, float brightness, float contrast, float gamma)
+			{
+				input.rgb *= rgbScale;
+
+				float3 hsv = RGBToHSV(input.rgb);
+				if (hsvOffs.x < 0.0f) hsvOffs.x += 2.0f;
+				hsv += hsvOffs;
+				hsv.x = fmod(hsv.x, 1.0f);
+				hsv = saturate(hsv);	// Prevent illegal colors
+
+				input.rgb = HSVToRGB(hsv);
+				input.rgb = contrast * (pow(input.rgb, 1.0f / gamma) - 0.5f) + 0.5f + brightness;
+
+				return input;
+			}
+
+            float4 frag (v2f i) : SV_Target
+            {
+                float4 col = tex2D(_MainTex, i.uv);
+                return ColorCorrect(col, float3(_RScale, _GScale, _BScale), float3(_HOffset, _SOffset, _VOffset), _Brightness, _Contrast, _Gamma);
+            }
+            ENDCG
+        }
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/ColorCorrection.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fd14a350c1446084087e4b6628a34472
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/HoloAlpha.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/HoloAlpha.shader
@@ -54,7 +54,7 @@ Shader "SV/HoloAlpha"
                 fixed4 backCol = tex2D(_BackTex, i.uv);
                 fixed4 frontCol = tex2D(_FrontTex, i.uv);
 
-                float occlusionAlpha = _OcclusionTexture.Sample(sampler_point_clamp, float2(i.uv[0], 1-i.uv[1])).r;
+                float occlusionAlpha = _OcclusionTexture.Sample(sampler_point_clamp, float2(i.uv[0], i.uv[1])).r;
 
                 float alpha = occlusionAlpha * _Alpha;
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/OcclusionMask.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/OcclusionMask.shader
@@ -4,8 +4,8 @@
     {
         _BodyMaskTexture("BodyMaskTexture", 2D) = "white" {}
         _DepthTexture("DepthTexture", 2D) = "white" {}
-        _MinDepth("Min Depth", Float) = 0
-        _MaxDepth("Max Depth", Float) = 10.0
+		_MinHologramDepth("Starting Hologram Depth", Float) = 0
+        _MaxOcclusionDepth("Maximum Occlusion Depth", Float) = 10.0
     }
     SubShader
     {
@@ -44,8 +44,8 @@
             Texture2D _DepthTexture;
             sampler2D_float _LastCameraDepthTexture;
             SamplerState sampler_point_clamp;
-            float _MinDepth;
-            float _MaxDepth;
+            float _MinHologramDepth;
+            float _MaxOcclusionDepth;
 
             fixed4 frag (v2f i) : SV_Target
             {
@@ -53,10 +53,17 @@
 
                 float rawHologramDepth = SAMPLE_DEPTH_TEXTURE(_LastCameraDepthTexture, i.uv);
                 float hologramDepth = LinearEyeDepth(rawHologramDepth);
-                float kinectDepth = _DepthTexture.Sample(sampler_point_clamp, float2(i.uv[0], i.uv[1])).r * 65535 * 0.001; // Incoming texture is R16
+                float kinectDepth = _DepthTexture.Sample(sampler_point_clamp, float2(i.uv[0], 1-i.uv[1])).r * 65535 * 0.001; // Incoming texture is R16
 
-                kinectDepth = (kinectDepth > _MinDepth && kinectDepth < _MaxDepth) ? kinectDepth : 0.0f;
-                float isHologramOccluded = kinectDepth > 0.0f && rawHologramDepth < 1.0f && kinectDepth < hologramDepth;
+				bool useKinectDepth = (kinectDepth > 0.0f) && (kinectDepth < _MaxOcclusionDepth);
+				bool useHologramDepth = (hologramDepth > _MinHologramDepth) && (rawHologramDepth < 1.0f);
+
+				float isHologramOccluded = 0.0f;
+				if (!useHologramDepth || 
+					(useHologramDepth && useKinectDepth && (kinectDepth < hologramDepth)))
+				{
+					isHologramOccluded = 1.0f;
+				}
 
                 float bodyMask = _BodyMaskTexture.Sample(sampler_point_clamp, float2(i.uv[0], i.uv[1])).r * 65535;
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/OcclusionMask.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/OcclusionMask.shader
@@ -4,8 +4,6 @@
     {
         _BodyMaskTexture("BodyMaskTexture", 2D) = "white" {}
         _DepthTexture("DepthTexture", 2D) = "white" {}
-		_MinHologramDepth("Starting Hologram Depth", Float) = 0
-        _MaxOcclusionDepth("Maximum Occlusion Depth", Float) = 10.0
     }
     SubShader
     {
@@ -44,8 +42,6 @@
             Texture2D _DepthTexture;
             sampler2D_float _LastCameraDepthTexture;
             SamplerState sampler_point_clamp;
-            float _MinHologramDepth;
-            float _MaxOcclusionDepth;
 
             fixed4 frag (v2f i) : SV_Target
             {
@@ -55,8 +51,8 @@
                 float hologramDepth = LinearEyeDepth(rawHologramDepth);
                 float kinectDepth = _DepthTexture.Sample(sampler_point_clamp, float2(i.uv[0], 1-i.uv[1])).r * 65535 * 0.001; // Incoming texture is R16
 
-				bool useKinectDepth = (kinectDepth > 0.0f) && (kinectDepth < _MaxOcclusionDepth);
-				bool useHologramDepth = (hologramDepth > _MinHologramDepth) && (rawHologramDepth < 1.0f);
+				bool useKinectDepth = kinectDepth > 0.0f;
+				bool useHologramDepth = rawHologramDepth < 1.0f;
 
 				float isHologramOccluded = 0.0f;
 				if (!useHologramDepth || 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/OcclusionMask.shader
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Shaders/OcclusionMask.shader
@@ -4,6 +4,8 @@
     {
         _BodyMaskTexture("BodyMaskTexture", 2D) = "white" {}
         _DepthTexture("DepthTexture", 2D) = "white" {}
+        _MinDepth("Min Depth", Float) = 0
+        _MaxDepth("Max Depth", Float) = 10.0
     }
     SubShader
     {
@@ -42,6 +44,8 @@
             Texture2D _DepthTexture;
             sampler2D_float _LastCameraDepthTexture;
             SamplerState sampler_point_clamp;
+            float _MinDepth;
+            float _MaxDepth;
 
             fixed4 frag (v2f i) : SV_Target
             {
@@ -51,6 +55,7 @@
                 float hologramDepth = LinearEyeDepth(rawHologramDepth);
                 float kinectDepth = _DepthTexture.Sample(sampler_point_clamp, float2(i.uv[0], i.uv[1])).r * 65535 * 0.001; // Incoming texture is R16
 
+                kinectDepth = (kinectDepth > _MinDepth && kinectDepth < _MaxDepth) ? kinectDepth : 0.0f;
                 float isHologramOccluded = kinectDepth > 0.0f && rawHologramDepth < 1.0f && kinectDepth < hologramDepth;
 
                 float bodyMask = _BodyMaskTexture.Sample(sampler_point_clamp, float2(i.uv[0], i.uv[1])).r * 65535;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private SpectatorViewTimeSynchronizer timeSynchronizer = new SpectatorViewTimeSynchronizer();
 
         private Camera spectatorCamera;
-        private GameObject videoCameraPose;
+        public GameObject VideoCameraPose { get; private set; }
 
         /// <summary>
         /// Gets the index of the video frame currently being composited.
@@ -581,16 +581,16 @@ namespace Microsoft.MixedReality.SpectatorView
         {
 #if UNITY_EDITOR
             this.calibrationData = calibrationData;
-            if (videoCameraPose == null)
+            if (VideoCameraPose == null)
             {
-                videoCameraPose = new GameObject("Camera HMD Pose");
+                VideoCameraPose = new GameObject("Camera HMD Pose");
             }
 
-            videoCameraPose.transform.SetParent(parent);
-            videoCameraPose.transform.localPosition = Vector3.zero;
-            videoCameraPose.transform.localRotation = Quaternion.identity;
+            VideoCameraPose.transform.SetParent(parent);
+            VideoCameraPose.transform.localPosition = Vector3.zero;
+            VideoCameraPose.transform.localRotation = Quaternion.identity;
 
-            gameObject.transform.parent = videoCameraPose.transform;
+            gameObject.transform.parent = VideoCameraPose.transform;
 
             calibrationData.SetUnityCameraExtrinstics(transform);
             calibrationData.SetUnityCameraIntrinsics(GetComponent<Camera>());

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/HolographicCameraObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/HolographicCameraObserver.cs
@@ -30,6 +30,19 @@ namespace Microsoft.MixedReality.SpectatorView
 
         protected override int RemotePort => remotePort;
 
+        public GameObject SharedSpatialCoordinateProxy
+        {
+            get
+            {
+                if (sharedSpatialCoordinateProxy == null)
+                {
+                    sharedSpatialCoordinateProxy = new GameObject("App HMD Shared Spatial Coordinate");
+                    sharedSpatialCoordinateProxy.transform.SetParent(transform, worldPositionStays: true);
+                }
+
+                return sharedSpatialCoordinateProxy;
+            }
+        }
         private GameObject sharedSpatialCoordinateProxy;
 
         protected override void Awake()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -213,6 +213,8 @@ namespace Microsoft.MixedReality.SpectatorView
         public event Action TextureRenderCompleted;
 
         public ColorCorrection videoFeedColorCorrection { get; set; }
+        public float occlusionMinDepth { get; set; } = 0;
+        public float occlusionMaxDepth { get; set; } = 10;
 
         private Material ignoreAlphaMat;
         private Material BGRToRGBMat;
@@ -337,6 +339,8 @@ namespace Microsoft.MixedReality.SpectatorView
             colorCorrectionMat = LoadMaterial("ColorCorrection");
 
             videoFeedColorCorrection = ColorCorrection.GetColorCorrection(VideoFeedColorCorrectionPlayerPrefName);
+            occlusionMinDepth = PlayerPrefs.GetFloat($"{nameof(TextureManager)}.{nameof(occlusionMinDepth)}", 0);
+            occlusionMaxDepth = PlayerPrefs.GetFloat($"{nameof(TextureManager)}.{nameof(occlusionMaxDepth)}", 10);
 
             SetHologramShaderAlpha(Compositor.DefaultAlpha);
 
@@ -374,6 +378,8 @@ namespace Microsoft.MixedReality.SpectatorView
         private void OnDestroy()
         {
             ColorCorrection.StoreColorCorrection(VideoFeedColorCorrectionPlayerPrefName, videoFeedColorCorrection);
+            PlayerPrefs.SetFloat($"{nameof(TextureManager)}.{nameof(occlusionMinDepth)}", occlusionMinDepth);
+            PlayerPrefs.SetFloat($"{nameof(TextureManager)}.{nameof(occlusionMaxDepth)}", occlusionMaxDepth);
         }
 
         private void SetupCameraAndRenderTextures()
@@ -496,6 +502,8 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 occlusionMaskMat.SetTexture("_DepthTexture", depthTexture);
                 occlusionMaskMat.SetTexture("_BodyMaskTexture", bodyMaskTexture);
+                occlusionMaskMat.SetFloat("_MinDepth", occlusionMinDepth);
+                occlusionMaskMat.SetFloat("_MaxDepth", occlusionMaxDepth);
                 Graphics.Blit(sourceTexture, occlusionMaskTexture, occlusionMaskMat);
 
                 blurMat.SetTexture("_MaskTexture", occlusionMaskTexture);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -167,11 +167,6 @@ namespace Microsoft.MixedReality.SpectatorView
         public RenderTexture blurOcclusionTexture { get; private set; }
 
         /// <summary>
-        /// A helper texture used to create the occlusion mask
-        /// </summary>
-        private RenderTexture blurOcclusionHelperTexture = null;
-
-        /// <summary>
         /// The raw color image data coming from the capture card
         /// </summary>
         private Texture2D colorTexture = null;
@@ -427,7 +422,6 @@ namespace Microsoft.MixedReality.SpectatorView
             compositeTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
             occlusionMaskTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
             blurOcclusionTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
-            blurOcclusionHelperTexture = new RenderTexture(frameWidth, frameHeight, (int)Compositor.TextureDepth);
 
             if (supersampleBuffers.Length > 0)
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -219,8 +219,6 @@ namespace Microsoft.MixedReality.SpectatorView
         public event Action TextureRenderCompleted;
 
         public ColorCorrection videoFeedColorCorrection { get; set; }
-        public float occlusionMinHologramDepth { get; set; } = 0;
-        public float occlusionMaxDepth { get; set; } = 10;
         public float blurSize { get; set; } = 5;
 
         private Material ignoreAlphaMat;
@@ -346,8 +344,6 @@ namespace Microsoft.MixedReality.SpectatorView
             colorCorrectionMat = LoadMaterial("ColorCorrection");
 
             videoFeedColorCorrection = ColorCorrection.GetColorCorrection(VideoFeedColorCorrectionPlayerPrefName);
-            occlusionMinHologramDepth = PlayerPrefs.GetFloat($"{nameof(TextureManager)}.{nameof(occlusionMinHologramDepth)}", 0);
-            occlusionMaxDepth = PlayerPrefs.GetFloat($"{nameof(TextureManager)}.{nameof(occlusionMaxDepth)}", 10);
             blurSize = PlayerPrefs.GetFloat($"{nameof(TextureManager)}.{nameof(blurSize)}", 5);
 
             SetHologramShaderAlpha(Compositor.DefaultAlpha);
@@ -386,8 +382,6 @@ namespace Microsoft.MixedReality.SpectatorView
         private void OnDestroy()
         {
             ColorCorrection.StoreColorCorrection(VideoFeedColorCorrectionPlayerPrefName, videoFeedColorCorrection);
-            PlayerPrefs.SetFloat($"{nameof(TextureManager)}.{nameof(occlusionMinHologramDepth)}", occlusionMinHologramDepth);
-            PlayerPrefs.SetFloat($"{nameof(TextureManager)}.{nameof(occlusionMaxDepth)}", occlusionMaxDepth);
             PlayerPrefs.SetFloat($"{nameof(TextureManager)}.{nameof(blurSize)}", blurSize);
         }
 
@@ -491,8 +485,6 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 occlusionMaskMat.SetTexture("_DepthTexture", depthTexture);
                 occlusionMaskMat.SetTexture("_BodyMaskTexture", bodyMaskTexture);
-                occlusionMaskMat.SetFloat("_MinHologramDepth", occlusionMinHologramDepth);
-                occlusionMaskMat.SetFloat("_MaxOcclusionDepth", occlusionMaxDepth);
                 Graphics.Blit(sourceTexture, occlusionMaskTexture, occlusionMaskMat);
 
                 blurMat.SetTexture("_MaskTexture", occlusionMaskTexture);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -340,8 +340,10 @@ namespace Microsoft.MixedReality.SpectatorView
             }
         }
 
-        private void OnPostRender()
+        private IEnumerator OnPostRender()
         {
+            yield return new WaitForEndOfFrame();
+
             displayOutputTexture.DiscardContents();
 
             RenderTexture sourceTexture = spectatorViewCamera.targetTexture;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.SpectatorView
     public enum FrameProviderDeviceType : int { BlackMagic = 0, Elgato = 1, AzureKinect_DepthCamera_Off = 2, AzureKinect_DepthCamera_NFOV = 3, AzureKinect_DepthCamera_WFOV = 4, None = 5 };
     public enum OcclusionSetting : int { RawDepthCamera = 0, BodyTracking = 1};
     public enum VideoRecordingFrameLayout : int { Composite = 0, Quad = 1 };
+    public enum PreviewTextureMode : int { Composite = 0, Quad = 1, OcclusionMask = 2 }
 
 #if UNITY_EDITOR
     internal struct CompositorVector3

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorCoordinateService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorCoordinateService.cs
@@ -73,6 +73,7 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 GameObject anchorGameObject = new GameObject(knownId);
                 WorldAnchor anchor = store.Load(knownId, anchorGameObject);
+                UnityEngine.Object.DontDestroyOnLoad(anchorGameObject);
 
                 if (anchor == null)
                 {
@@ -96,6 +97,7 @@ namespace Microsoft.MixedReality.SpectatorView
             gameObject.transform.position = worldPosition;
             gameObject.transform.rotation = worldRotation;
             WorldAnchor anchor = gameObject.AddComponent<WorldAnchor>();
+            UnityEngine.Object.DontDestroyOnLoad(gameObject);
 
             if (anchor.isLocated)
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorCoordinateService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/WorldAnchor/WorldAnchorCoordinateService.cs
@@ -73,7 +73,6 @@ namespace Microsoft.MixedReality.SpectatorView
             {
                 GameObject anchorGameObject = new GameObject(knownId);
                 WorldAnchor anchor = store.Load(knownId, anchorGameObject);
-                UnityEngine.Object.DontDestroyOnLoad(anchorGameObject);
 
                 if (anchor == null)
                 {
@@ -97,7 +96,6 @@ namespace Microsoft.MixedReality.SpectatorView
             gameObject.transform.position = worldPosition;
             gameObject.transform.rotation = worldRotation;
             WorldAnchor anchor = gameObject.AddComponent<WorldAnchor>();
-            UnityEngine.Object.DontDestroyOnLoad(gameObject);
 
             if (anchor.isLocated)
             {


### PR DESCRIPTION
This review contains the following changes:

1) Min and max depth now exists in the occlusion mask shader for raw depth images. Users can manipulate these values in the Compositor Window to affect the range of depth data used when filming with azure kinect.
2) This branch also contains reviews checked into the master branch