### PR TITLE
Use the correct number of coefficients for the ArUco marker detector

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.cpp
@@ -210,11 +210,14 @@ void AzureKinectFrameProvider::UpdateArUcoMarkers(k4a_image_t image)
         auto width = k4a_image_get_width_pixels(image);
         auto buffer = k4a_image_get_buffer(image);
 
+        const int radialDistortionCount = 6;
+        const int tangentialDistortionCount = 2;
+
         float focalLength[2] = { calibration.color_camera_calibration.intrinsics.parameters.param.fx, calibration.color_camera_calibration.intrinsics.parameters.param.fy };
         float principalPoint[2] = { calibration.color_camera_calibration.intrinsics.parameters.param.cx, calibration.color_camera_calibration.intrinsics.parameters.param.cy };
-        float radialDistortion[3] = { calibration.color_camera_calibration.intrinsics.parameters.param.k1, calibration.color_camera_calibration.intrinsics.parameters.param.k2, calibration.color_camera_calibration.intrinsics.parameters.param.k3 };
-        float tangentialDistortion[2] = { calibration.color_camera_calibration.intrinsics.parameters.param.p1, calibration.color_camera_calibration.intrinsics.parameters.param.p2 };
-        markerDetector->DetectMarkers(buffer, width, height, focalLength, principalPoint, radialDistortion, tangentialDistortion, markerSize, markerDictionaryName);
+        float radialDistortion[radialDistortionCount] = { calibration.color_camera_calibration.intrinsics.parameters.param.k1, calibration.color_camera_calibration.intrinsics.parameters.param.k2, calibration.color_camera_calibration.intrinsics.parameters.param.k3, calibration.color_camera_calibration.intrinsics.parameters.param.k4, calibration.color_camera_calibration.intrinsics.parameters.param.k5, calibration.color_camera_calibration.intrinsics.parameters.param.k6 };
+        float tangentialDistortion[tangentialDistortionCount] = { calibration.color_camera_calibration.intrinsics.parameters.param.p1, calibration.color_camera_calibration.intrinsics.parameters.param.p2 };
+        markerDetector->DetectMarkers(buffer, width, height, focalLength, principalPoint, radialDistortion, radialDistortionCount, tangentialDistortion, tangentialDistortionCount, markerSize, markerDictionaryName);
     }
 }
 

--- a/src/SpectatorView.Native/SpectatorView.OpenCV/SharedFiles/ArUcoMarkerDetector.cpp
+++ b/src/SpectatorView.Native/SpectatorView.OpenCV/SharedFiles/ArUcoMarkerDetector.cpp
@@ -32,7 +32,9 @@ bool ArUcoMarkerDetector::DetectMarkers(
     float* focalLength,
     float* principalPoint,
     float* radialDistortion,
+    int radialDistortionCount,
     float* tangentialDistortion,
+    int tangentialDistortionCount,
     float markerSize,
     int arUcoMarkerDictionaryId)
 {
@@ -75,12 +77,21 @@ bool ArUcoMarkerDetector::DetectMarkers(
     cameraMatrix.at<double>(2, 2) = 1.0; // Default value for camera intrinsic matrix
     OutputDebugMatrix<double>(L"Camera Matrix: ", cameraMatrix);
 
-    cv::Mat distCoeffMatrix(1, 5, CV_64F, cv::Scalar(0));
-    distCoeffMatrix.at<double>(0, 0) = radialDistortion[0]; // r1 radial distortion
-    distCoeffMatrix.at<double>(0, 1) = radialDistortion[1]; // r2 radial distortion
-    distCoeffMatrix.at<double>(0, 2) = tangentialDistortion[0]; // t1 tangential distortion
-    distCoeffMatrix.at<double>(0, 3) = tangentialDistortion[1]; // t2 tangential distortion
-    distCoeffMatrix.at<double>(0, 4) = radialDistortion[2]; // r3 radial distortion
+    cv::Mat distCoeffMatrix(1, radialDistortionCount + tangentialDistortionCount, CV_64F, cv::Scalar(0));
+    int coefficientIndex = 0;
+    for (int i = 0; i < 2 && i < radialDistortionCount; i++, coefficientIndex++) 
+    {
+        distCoeffMatrix.at<double>(0, coefficientIndex) = radialDistortion[i];
+    }
+    for (int i = 0; i < tangentialDistortionCount; i++, coefficientIndex++)
+    {
+        distCoeffMatrix.at<double>(0, coefficientIndex) = tangentialDistortion[i];
+    }
+    for (int i = 2; i < radialDistortionCount; i++, coefficientIndex++)
+    {
+        distCoeffMatrix.at<double>(0, coefficientIndex) = radialDistortion[i];
+    }
+
     OutputDebugMatrix<double>(L"Distortion Coefficients: ", distCoeffMatrix);
 
     std::vector<cv::Vec3d> rotationVecs;

--- a/src/SpectatorView.Native/SpectatorView.OpenCV/SharedFiles/ArUcoMarkerDetector.h
+++ b/src/SpectatorView.Native/SpectatorView.OpenCV/SharedFiles/ArUcoMarkerDetector.h
@@ -14,7 +14,9 @@ public:
         float* focalLength,
         float* principalPoint,
         float* radialDistortion,
+        int radialDistortionCount,
         float* tangentialDistortion,
+        int tangentialDistortionCount,
         float markerSize,
         int arUcoMarkerDictionaryId);
     inline int GetDetectedMarkersCount() { return static_cast<int>(_detectedMarkers.size()); }

--- a/src/SpectatorView.Native/SpectatorView.OpenCV/SharedFiles/SpectatorViewPlugin.cpp
+++ b/src/SpectatorView.Native/SpectatorView.OpenCV/SharedFiles/SpectatorViewPlugin.cpp
@@ -38,7 +38,9 @@ extern "C" __declspec(dllexport) bool __stdcall DetectMarkers(
     float* focalLength,
     float* principalPoint,
     float* radialDistortion,
+    int radialDistortionCount,
     float* tangentialDistortion,
+    int tangentialDistortionCount,
     float markerSize,
     int arUcoMarkerDictionaryId)
 {
@@ -51,7 +53,9 @@ extern "C" __declspec(dllexport) bool __stdcall DetectMarkers(
             focalLength,
             principalPoint,
             radialDistortion,
+            radialDistortionCount,
             tangentialDistortion,
+            tangentialDistortionCount,
             markerSize,
             arUcoMarkerDictionaryId);
     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewOpenCVInterface.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewOpenCVInterface.cs
@@ -26,7 +26,9 @@ namespace Microsoft.MixedReality.SpectatorView
             float[] focalLength,
             float[] principalPoint,
             float[] radialDistortion,
+            int radialDistortionCount,
             float[] tangentialDistortion,
+            int tangentialDistortionCount,
             float markerSize,
             int arUcoMarkerDictionaryId);
 
@@ -130,7 +132,9 @@ namespace Microsoft.MixedReality.SpectatorView
                 focalLength,
                 principalPoint,
                 radialDistortion,
+                radialDistortion.Length,
                 tangentialDistortion,
+                tangentialDistortion.Length,
                 _markerSize,
                 _arucoDictionaryId))
             {


### PR DESCRIPTION
Azure Kinect uses the Brown Conrady distortion model, which has 6 radial coefficients and two tangential coefficients. This change improves the quality of ArUco marker detection with the Azure Kinect.