### PR TITLE
Fix two K4A bugs related to body tracking.

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.h
@@ -80,7 +80,7 @@ private:
     k4a_depth_mode_t depthCameraMode = K4A_DEPTH_MODE_OFF;
 
 #if defined(INCLUDE_AZUREKINECT_BODYTRACKING)
-    k4abt_tracker_t k4abtTracker;
+    k4abt_tracker_t k4abtTracker = nullptr;
     k4abt_tracker_configuration_t tracker_config = K4ABT_TRACKER_CONFIG_DEFAULT;
 #endif
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.h
@@ -52,8 +52,10 @@ public:
     virtual void GetLatestArUcoMarkers(int size, Marker* markers) override;
 
 private:
+#if defined(INCLUDE_AZUREKINECT_BODYTRACKING)
     void GetBodyIndexMap(k4a_capture_t capture, k4abt_frame_t* bodyFrame, k4a_image_t* bodyIndexMap, uint8_t** bodyIndexBuffer);
     void ReleaseBodyIndexMap(k4abt_frame_t bodyFrame, k4a_image_t bodyIndexMap);
+#endif
     void UpdateSRV(k4a_image_t bodyDepthImage, ID3D11ShaderResourceView* _srv);
     void UpdateArUcoMarkers(k4a_image_t image);
     void SetBodyMaskBuffer(uint16_t* bodyMaskBuffer, uint8_t* bodyIndexBuffer, int bufferSize);


### PR DESCRIPTION
This PR fixes:

- the compilation of the native compositor library when the kinect for azure is used without the body tracking SDK
- a crash when body tracking was not used but built as debug dll. <br/>some friendly entity initialized the `k4abtTracker` to `nullptr` when compiled as release. In debug mode msvc sets uninitialized members to `0xcd` so Unity crashed at `AzureKinectFrameProvider.cpp:348`.