### PR TITLE
Feature: Use alternative capture card output

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.cpp
@@ -353,7 +353,7 @@ void AzureKinectFrameProvider::Dispose()
     DeleteCriticalSection(&lock);
 }
 
-bool AzureKinectFrameProvider::OutputYUV()
+bool AzureKinectFrameProvider::ProvidesYUV()
 {
     return false;
 }

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectFrameProvider.h
@@ -27,7 +27,7 @@ public:
     virtual bool IsEnabled() override;
     virtual bool SupportsOutput() override;
     virtual void Dispose() override;
-    virtual bool OutputYUV() override;
+    virtual bool ProvidesYUV() override;
 
     virtual int GetCaptureFrameIndex() override
     {

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
@@ -420,14 +420,22 @@ void CompositorInterface::RecordAudioFrameAsync(BYTE* audioFrame, LONGLONG audio
     activeVideoEncoder->QueueAudioFrame(audioFrame, audioSize, sampleTime);
 }
 
-bool CompositorInterface::OutputYUV()
+bool CompositorInterface::ProvidesYUV()
 {
-    if (outputFrameProvider != nullptr)
-        return outputFrameProvider->OutputYUV();
     if (frameProvider == nullptr)
     {
         return false;
     }
 
-    return frameProvider->OutputYUV();
+    return frameProvider->ProvidesYUV();
+}
+
+bool CompositorInterface::ExpectsYUV()
+{
+    if (outputFrameProvider != nullptr)
+        return outputFrameProvider->ExpectsYUV();
+    if (frameProvider != nullptr)
+        return frameProvider->ExpectsYUV();
+
+    return false;
 }

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
@@ -219,7 +219,9 @@ void CompositorInterface::UpdateFrameProvider()
         frameProvider->Update(compositeFrameIndex);
     }
     if (outputFrameProvider != nullptr)
+    {
         outputFrameProvider->Update(compositeFrameIndex);
+    }
 }
 
 void CompositorInterface::Update()

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
@@ -53,6 +53,13 @@ void CompositorInterface::SetOutputFrameProvider(IFrameProvider::ProviderType ty
 {
     DisableOutputFrameProvider();
 
+    // There is no need for a second instance of the same provider type
+    IFrameProvider::ProviderType inputProviderType = IFrameProvider::ProviderType::None;
+    if (frameProvider != nullptr)
+        inputProviderType = frameProvider->GetProviderType();
+    if (inputProviderType == type)
+        return;
+
 #if defined (INCLUDE_BLACKMAGIC)
     if (type == IFrameProvider::ProviderType::BlackMagic)
         outputFrameProvider = new DeckLinkManager();

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
@@ -22,6 +22,7 @@ class CompositorInterface
 {
 private:
     IFrameProvider* frameProvider;
+    IFrameProvider* outputFrameProvider = nullptr;
     float alpha = 0.9f;
 
     VideoEncoder* videoEncoder1080p = nullptr;
@@ -42,7 +43,10 @@ private:
 public:
     DLLEXPORT CompositorInterface();
     DLLEXPORT void SetFrameProvider(IFrameProvider::ProviderType type);
+    DLLEXPORT void SetOutputFrameProvider(IFrameProvider::ProviderType type);
+    DLLEXPORT void DisableOutputFrameProvider();
 	DLLEXPORT bool IsFrameProviderSupported(IFrameProvider::ProviderType providerType);
+    DLLEXPORT bool IsOutputFrameProviderSupported(IFrameProvider::ProviderType providerType);
     DLLEXPORT bool IsOcclusionSettingSupported(IFrameProvider::OcclusionSetting setting);
     DLLEXPORT bool IsCameraCalibrationInformationAvailable();
     DLLEXPORT void GetCameraCalibrationInformation(CameraIntrinsics* cameraIntrinsics);

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
@@ -94,7 +94,8 @@ public:
         return alpha;
     }
 
-    DLLEXPORT bool OutputYUV();
+    DLLEXPORT bool ProvidesYUV();
+    DLLEXPORT bool ExpectsYUV();
 
 public:
     int compositeFrameIndex;

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
@@ -778,11 +778,15 @@ void DeckLinkDevice::Update(int compositeFrameIndex)
     }
 }
 
-bool DeckLinkDevice::OutputYUV()
+bool DeckLinkDevice::ProvidesYUV()
 {
     return (pixelFormat == PixelFormat::YUV);
 }
 
+bool DeckLinkDevice::ExpectsYUV()
+{
+    return ProvidesYUV();
+}
 
 void DeckLinkDevice::BufferCache::ComputePixelChange(BYTE* prevBuffer, BMDPixelFormat framePixelFormat)
 {

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
@@ -468,8 +468,10 @@ bool DeckLinkDevice::Init(ID3D11ShaderResourceView* colorSRV, ID3D11Texture2D* o
         if (m_deckLink->QueryInterface(IID_IDeckLinkInput, (void**)&m_deckLinkInput) != S_OK)
             return false;
     }
-    if (device == nullptr && outputTexture != nullptr)
+    else if (outputTexture != nullptr)
+    {
         outputTexture->GetDevice(&device);
+    }
 
     if (m_deckLink->QueryInterface(IID_IDeckLinkOutput, (void**)&m_deckLinkOutput) != S_OK)
     {

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
@@ -44,7 +44,7 @@ private:
         BGRA
     };
 
-    PixelFormat pixelFormat = PixelFormat::BGRA;
+    PixelFormat pixelFormat = PixelFormat::YUV;
 
     ULONG                     m_refCount;
     IDeckLink*                m_deckLink;
@@ -140,7 +140,8 @@ public:
 
     int GetNumQueuedOutputFrames();
 
-    bool OutputYUV();
+    bool ProvidesYUV();
+    bool ExpectsYUV();
 };
 
 class DeckLinkDeviceDiscovery :  public IDeckLinkDeviceNotificationCallback

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
@@ -44,7 +44,7 @@ private:
         BGRA
     };
 
-    PixelFormat pixelFormat = PixelFormat::YUV;
+    PixelFormat pixelFormat = PixelFormat::BGRA;
 
     ULONG                     m_refCount;
     IDeckLink*                m_deckLink;
@@ -84,13 +84,12 @@ private:
 
     ID3D11ShaderResourceView* _colorSRV;
     ID3D11Texture2D* _outputTexture;
-    ID3D11Device* device;
+    ID3D11Device* device = nullptr;
 
     bool _useCPU;
     bool _passthroughOutput;
     BufferedTextureFetch outputTextureBuffer;
 
-    void SetupVideoOutputFrame(BMDDisplayMode videoDisplayMode);
     int lastCompositorFrameIndex = -1;
 
 public:
@@ -99,8 +98,10 @@ public:
 
     bool                                Init(ID3D11ShaderResourceView* colorSRV, ID3D11Texture2D* outputTexture, bool useCPU = false, bool passthroughOutput = false);
     bool                                IsCapturing() { return m_currentlyCapturing; };
+    bool                                IsOutputOnly() { return _colorSRV == nullptr && m_deckLinkOutput != nullptr; }
     bool                                SupportsFormatDetection() { return (m_supportsFormatDetection == TRUE); };
     bool                                StartCapture(BMDDisplayMode videoDisplayMode);
+    void                                SetupVideoOutputFrame(BMDDisplayMode videoDisplayMode);
     void                                StopCapture();
     IDeckLink*                          DeckLinkInstance() { return m_deckLink; }
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
@@ -87,7 +87,9 @@ HRESULT DeckLinkManager::Initialize(ID3D11ShaderResourceView* colorSRV, ID3D11Sh
                     }
 
                     if (colorSRV != nullptr)
+                    {
                         deckLinkDevice->StartCapture(videoDisplayMode);
+                    }
                     deckLinkDevice->SetupVideoOutputFrame(videoDisplayMode);
                     return S_OK;
                 }

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
@@ -86,7 +86,9 @@ HRESULT DeckLinkManager::Initialize(ID3D11ShaderResourceView* colorSRV, ID3D11Sh
                         videoDisplayMode = bmdMode4kDCI2398;
                     }
 
-                    deckLinkDevice->StartCapture(videoDisplayMode);
+                    if (colorSRV != nullptr)
+                        deckLinkDevice->StartCapture(videoDisplayMode);
+                    deckLinkDevice->SetupVideoOutputFrame(videoDisplayMode);
                     return S_OK;
                 }
             }
@@ -175,7 +177,7 @@ bool DeckLinkManager::IsEnabled()
         return false;
     }
     
-    return deckLinkDevice->IsCapturing();
+    return deckLinkDevice->IsCapturing() || deckLinkDevice->IsOutputOnly();
 }
 
 void DeckLinkManager::Dispose()

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
@@ -108,14 +108,25 @@ bool DeckLinkManager::SupportsOutput()
     return false;
 }
 
-bool DeckLinkManager::OutputYUV()
+bool DeckLinkManager::ProvidesYUV()
 {
     if (!IsEnabled())
     {
         return false;
     }
 
-    return deckLinkDevice->OutputYUV();
+    return deckLinkDevice->ProvidesYUV();
+}
+
+
+bool DeckLinkManager::ExpectsYUV()
+{
+    if (!IsEnabled())
+    {
+        return false;
+    }
+
+    return deckLinkDevice->ExpectsYUV();
 }
 
 LONGLONG DeckLinkManager::GetTimestamp(int frame)

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
@@ -32,7 +32,8 @@ public:
 
     void Dispose();
 
-    bool OutputYUV();
+    bool ProvidesYUV();
+    bool ExpectsYUV();
 
 private:
     DeckLinkDeviceDiscovery* deckLinkDiscovery = nullptr;

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/ElgatoFrameProvider.h
@@ -59,7 +59,7 @@ public:
 
     virtual void Dispose();
 
-    bool OutputYUV()
+    bool ProvidesYUV()
     {
         return true;
     }

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
@@ -15,7 +15,8 @@ public:
         Elgato,
         AzureKinect_DepthCamera_Off,
         AzureKinect_DepthCamera_NFOV,
-        AzureKinect_DepthCamera_WFOV
+        AzureKinect_DepthCamera_WFOV,
+        None
     };
 
     enum OcclusionSetting

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
@@ -45,8 +45,10 @@ public:
     // Stop capturing frames from the FrameProvider.
     virtual void Dispose() = 0;
 
-    // Return true if function outputs YUV frames, false otherwise.
-    virtual bool OutputYUV() = 0;
+    // Return true if function provides YUV frames, false otherwise.
+    virtual bool ProvidesYUV() = 0;
+    // Return true if the output expects YUV frames, false otherwise.
+    virtual bool ExpectsYUV() { return false; }
 
     virtual int GetCaptureFrameIndex() { return 0; }
     virtual int GetPixelChange(int frame) { return 0; }

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -383,6 +383,16 @@ UNITYDLL bool IsFrameProviderSupported(int providerId)
 	return ci->IsFrameProviderSupported((IFrameProvider::ProviderType) providerId);
 }
 
+UNITYDLL bool IsOutputFrameProviderSupported(int providerId)
+{
+	if (ci == nullptr)
+	{
+		ci = new CompositorInterface();
+	}
+
+	return ci->IsOutputFrameProviderSupported((IFrameProvider::ProviderType) providerId);
+}
+
 UNITYDLL bool IsOcclusionSettingSupported(int setting)
 {
     if (ci == nullptr)
@@ -393,7 +403,7 @@ UNITYDLL bool IsOcclusionSettingSupported(int setting)
     return ci->IsOcclusionSettingSupported((IFrameProvider::OcclusionSetting) setting);
 }
 
-UNITYDLL bool InitializeFrameProviderOnDevice(int providerId)
+UNITYDLL bool InitializeFrameProviderOnDevice(int providerId, int outputProviderId)
 {
     if (g_outputTexture == nullptr ||
         g_UnityColorSRV == nullptr ||
@@ -413,6 +423,7 @@ UNITYDLL bool InitializeFrameProviderOnDevice(int providerId)
     }
 
     ci->SetFrameProvider((IFrameProvider::ProviderType) providerId);
+    ci->SetOutputFrameProvider((IFrameProvider::ProviderType) outputProviderId);
     isInitialized = ci->Initialize(g_pD3D11Device, g_UnityColorSRV, g_UnityDepthSRV, g_UnityBodySRV, g_outputTexture);
 
     return isInitialized;

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -537,14 +537,24 @@ UNITYDLL void Reset()
     LeaveCriticalSection(&lock);
 }
 
-UNITYDLL bool OutputYUV()
+UNITYDLL bool ProvidesYUV()
 {
     if (ci == nullptr)
     {
         return false;
     }
 
-    return ci->OutputYUV();
+    return ci->ProvidesYUV();
+}
+
+UNITYDLL bool ExpectsYUV()
+{
+    if (ci == nullptr)
+    {
+        return false;
+    }
+
+    return ci->ExpectsYUV();
 }
 
 UNITYDLL LONGLONG GetCurrentUnityTime()

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -145,25 +145,46 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                         if (compositionManager != null)
                         {
                             GUI.enabled = compositionManager == null || !compositionManager.IsVideoFrameProviderInitialized;
-                            GUIContent label = new GUIContent("Video source", "The video capture card you want to use as input for compositing.");
+                            GUIContent captureLabel = new GUIContent("Video source", "The video capture card you want to use as input for compositing.");
+                            GUIContent outputLabel = new GUIContent("Video output", "The video capture card you want to use as output after compositing.");
 
-                            var supportedDevices = Enum.GetValues(typeof(FrameProviderDeviceType))
+                            var supportedCaptureDevices = Enum.GetValues(typeof(FrameProviderDeviceType))
                                 .Cast<FrameProviderDeviceType>()
                                 .Where(provider => compositionManager.IsFrameProviderSupported(provider) || (provider == FrameProviderDeviceType.None)).ToList();
-                            var selectedIndex = supportedDevices.IndexOf(compositionManager.CaptureDevice);
+                            var selectedIndex = supportedCaptureDevices.IndexOf(compositionManager.CaptureDevice);
                             if (selectedIndex < 0)
                             {
-                                selectedIndex = supportedDevices.Count - 1;
+                                selectedIndex = supportedCaptureDevices.Count - 1;
                             }
 
-                            selectedIndex = EditorGUILayout.Popup(label, selectedIndex,
-                                supportedDevices
+                            selectedIndex = EditorGUILayout.Popup(captureLabel, selectedIndex,
+                                supportedCaptureDevices
                                 .Select(x => x.ToString())
                                 .ToArray());
 
-                            compositionManager.CaptureDevice = supportedDevices[selectedIndex];
+                            compositionManager.CaptureDevice = supportedCaptureDevices[selectedIndex];
 
-                            if ((supportedDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_NFOV && supportedDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_WFOV) || compositionManager.VideoRecordingLayout == VideoRecordingFrameLayout.Quad)
+                            EditorGUILayout.EndHorizontal();
+                            EditorGUILayout.Space();
+                            EditorGUILayout.BeginHorizontal();
+
+                            var supportedOutputDevices = Enum.GetValues(typeof(FrameProviderDeviceType))
+                                .Cast<FrameProviderDeviceType>()
+                                .Where(provider => compositionManager.IsOutputFrameProviderSupported(provider) || (provider == FrameProviderDeviceType.None)).ToList();
+                            selectedIndex = supportedOutputDevices.IndexOf(compositionManager.OutputDevice);
+                            if (selectedIndex < 0)
+                            {
+                                selectedIndex = supportedOutputDevices.Count - 1;
+                            }
+
+                            selectedIndex = EditorGUILayout.Popup(outputLabel, selectedIndex,
+                                supportedOutputDevices
+                                .Select(x => x.ToString())
+                                .ToArray());
+
+                            compositionManager.OutputDevice = supportedOutputDevices[selectedIndex];
+
+                            if ((supportedCaptureDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_NFOV && supportedCaptureDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_WFOV) || compositionManager.VideoRecordingLayout == VideoRecordingFrameLayout.Quad)
                             {
                                 GUI.enabled = false;
                             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -80,6 +80,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private float videoTimestampToHolographicTimestampOffset = -10.0f;
         private int captureDeviceIndex = -1;
+        private int outputDeviceIndex = -1;
         private int videoRecordingLayout = -1;
         private int occlusionMode = -1;
         private TextureManager textureManager = null;
@@ -186,6 +187,30 @@ namespace Microsoft.MixedReality.SpectatorView
                 {
                     captureDeviceIndex = (int)value;
                     PlayerPrefs.SetInt(nameof(CaptureDevice), captureDeviceIndex);
+                    PlayerPrefs.Save();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the type of output device to write video content to.
+        /// </summary>
+        public FrameProviderDeviceType OutputDevice
+        {
+            get
+            {
+                if (outputDeviceIndex == -1)
+                {
+                    outputDeviceIndex = PlayerPrefs.GetInt(nameof(OutputDevice), (int)FrameProviderDeviceType.None);
+                }
+                return (FrameProviderDeviceType)outputDeviceIndex;
+            }
+            set
+            {
+                if (outputDeviceIndex != (int)value)
+                {
+                    outputDeviceIndex = (int)value;
+                    PlayerPrefs.SetInt(nameof(OutputDevice), outputDeviceIndex);
                     PlayerPrefs.Save();
                 }
             }
@@ -407,13 +432,23 @@ namespace Microsoft.MixedReality.SpectatorView
         }
 
         /// <summary>
-        /// Returns true if the UnityCompositor dll supports the specified provider.
+        /// Returns true if the UnityCompositor dll supports the specified capture provider.
         /// </summary>
         /// <param name="providerId">provider to check</param>
         /// <returns>Returns true if the provider is supported, otherwise false.</returns>
         public bool IsFrameProviderSupported(FrameProviderDeviceType providerId)
         {
             return UnityCompositorInterface.IsFrameProviderSupported(providerId);
+        }
+
+        /// <summary>
+        /// Returns true if the UnityCompositor dll supports the specified output provider.
+        /// </summary>
+        /// <param name="providerId">provider to check</param>
+        /// <returns>Returns true if the provider is supported, otherwise false.</returns>
+        public bool IsOutputFrameProviderSupported(FrameProviderDeviceType providerId)
+        {
+            return UnityCompositorInterface.IsOutputFrameProviderSupported(providerId);
         }
 
         /// <summary>
@@ -528,9 +563,9 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (!isVideoFrameProviderInitialized)
             {
-                if (UnityCompositorInterface.IsFrameProviderSupported(CaptureDevice))
+                if (UnityCompositorInterface.IsFrameProviderSupported(CaptureDevice) && UnityCompositorInterface.IsOutputFrameProviderSupported(OutputDevice))
                 {
-                    isVideoFrameProviderInitialized = UnityCompositorInterface.InitializeFrameProviderOnDevice(CaptureDevice);
+                    isVideoFrameProviderInitialized = UnityCompositorInterface.InitializeFrameProviderOnDevice(CaptureDevice, OutputDevice);
                     if (isVideoFrameProviderInitialized)
                     {
                         CurrentCompositeFrame = 0;
@@ -546,7 +581,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 }
                 else
                 {
-                    Debug.LogWarning($"The current capture device, {CaptureDevice}, is not supported by your build of SpectatorView.Compositor.UnityPlugin.dll.");
+                    Debug.LogWarning($"The current device selection, Capture: {CaptureDevice}, Output: {OutputDevice}, is not supported by your build of SpectatorView.Compositor.UnityPlugin.dll.");
                 }
             }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -244,7 +244,8 @@ namespace Microsoft.MixedReality.SpectatorView
 
         private int frameWidth;
         private int frameHeight;
-        private bool outputYUV;
+        private bool providesYUV;
+        private bool expectsYUV;
         private bool hardwareEncodeVideo;
         private IntPtr renderEvent;
 
@@ -272,7 +273,7 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             get
             {
-                if (overrideColorTexture == null && outputYUV)
+                if (overrideColorTexture == null && providesYUV)
                 {
                     return YUVToRGBMat;
                 }
@@ -323,7 +324,8 @@ namespace Microsoft.MixedReality.SpectatorView
         {
             frameWidth = UnityCompositorInterface.GetFrameWidth();
             frameHeight = UnityCompositorInterface.GetFrameHeight();
-            outputYUV = UnityCompositorInterface.OutputYUV();
+            providesYUV = UnityCompositorInterface.ProvidesYUV();
+            expectsYUV = UnityCompositorInterface.ExpectsYUV();
             renderEvent = UnityCompositorInterface.GetRenderEventFunc();
             hardwareEncodeVideo = UnityCompositorInterface.HardwareEncodeVideo();
 
@@ -374,11 +376,8 @@ namespace Microsoft.MixedReality.SpectatorView
         private void Update()
         {
             // this updates after we start running or when the video source changes, so we need to check every frame
-            bool newOutputYUV = UnityCompositorInterface.OutputYUV();
-            if (outputYUV != newOutputYUV)
-            {
-                outputYUV = newOutputYUV;
-            }
+            providesYUV = UnityCompositorInterface.ProvidesYUV();
+            expectsYUV = UnityCompositorInterface.ExpectsYUV();
         }
 
         private void OnDestroy()
@@ -540,7 +539,7 @@ namespace Microsoft.MixedReality.SpectatorView
             // If an output texture override has been specified, use it instead of the composited texture
             Texture outputTexture = (overrideOutputTexture == null) ? compositeTexture : overrideOutputTexture;
 
-            Graphics.Blit(outputTexture, displayOutputTexture, outputYUV ? RGBToYUVMat : RGBToBGRMat);
+            Graphics.Blit(outputTexture, displayOutputTexture, expectsYUV ? RGBToYUVMat : RGBToBGRMat);
 
             Graphics.Blit(renderTexture, alphaTexture, extractAlphaMat);
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
@@ -167,10 +167,13 @@ namespace Microsoft.MixedReality.SpectatorView
         public static extern bool IsFrameProviderSupported([MarshalAs(UnmanagedType.I4)] FrameProviderDeviceType providerId);
 
         [DllImport(CompositorPluginDll)]
+        public static extern bool IsOutputFrameProviderSupported([MarshalAs(UnmanagedType.I4)] FrameProviderDeviceType providerId);
+
+        [DllImport(CompositorPluginDll)]
         public static extern bool IsOcclusionSettingSupported([MarshalAs(UnmanagedType.I4)] OcclusionSetting setting);
 
         [DllImport(CompositorPluginDll)]
-        public static extern bool InitializeFrameProviderOnDevice([MarshalAs(UnmanagedType.I4)] FrameProviderDeviceType providerId);
+        public static extern bool InitializeFrameProviderOnDevice([MarshalAs(UnmanagedType.I4)] FrameProviderDeviceType providerId, [MarshalAs(UnmanagedType.I4)] FrameProviderDeviceType outputProviderId);
 
         [DllImport(CompositorPluginDll)]
         public static extern void Reset();

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
@@ -140,7 +140,10 @@ namespace Microsoft.MixedReality.SpectatorView
         public static extern bool IsRecording();
 
         [DllImport(CompositorPluginDll)]
-        public static extern bool OutputYUV();
+        public static extern bool ProvidesYUV();
+
+        [DllImport(CompositorPluginDll)]
+        public static extern bool ExpectsYUV();
 
         [DllImport(CompositorPluginDll)]
         public static extern bool QueueingHoloFrames();


### PR DESCRIPTION
![pr_alt_cc_output](https://user-images.githubusercontent.com/62652869/78334646-6c3c8c00-758c-11ea-907d-26bf9ceb2a0a.png)

## Description

My team and I are quite impressed by this project and plan to use it on various occasions, both video recording and live events. For the latter, as a matter of precaution, we would like to pass every output through a capture card (instead of connecting the computer directly to the stage beamer). This PR adds the ability to select an alternative video output for the compositor, so e.g. you can use a Kinect For Azure as input but output through a BlackMagic capture card.
I tested this feature with a BlackMagic Ultrastudio Express (as Half-Duplex) and an Ultrastudio 4K Mini (as Full-Duplex). Unfortunately I could not test with an Elgato device.

## Summary of changes

- `CompositorInterface` has a second, optional `IFrameProvider` pointer and related functions to set it / check the support for a given `ProviderType`
- The new GUI popup was added to `CompositorWindow` 
- `DeckLinkDevice` and `DeckLinkManager` had to modified to support output without capturing.
- `IFrameProvider::OutputYUV` was split into `ProvidesYUV` and `ExpectsYUV` to support cases where the input provider only supports BGRA (e.g. K4A), but the output provider expects YUV frames (e.g. default with BlackMagic)

## Further points of improvement

- If/When further output providers are added to this project it might be cleaner to separate the output capabilities into its own interface (e.g. `IFrameReceiver`)
- It might be helpful to have frame-provider-specific configuration in the compositor window (e.g. to set output display mode for BM, depth camera mode for K4A, etc.). This could also eliminate the need for a `USE_DECKLINK_SHUTTLE` macro.