### PR TITLE
Make sure shutdown does not cause an AV when initialization did not complete successfully

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.cpp
@@ -109,7 +109,11 @@ FailedExit:
 AzureKinectCameraInput::~AzureKinectCameraInput()
 {
     _stopRequested = true;
-    _thread->join();
+
+    if (_thread != nullptr)
+    {
+        _thread->join();
+    }
 
 #if defined(INCLUDE_AZUREKINECT_BODYTRACKING)
     if (_bodyIndexThread != nullptr)


### PR DESCRIPTION
If you haven't configured the Azure Kinect body tracking components correctly, initialization won't complete successfully, but then shutdown will crash with a null dereference. This change adds a check to make sure the thread for processing is running before trying to join it.