### PR TITLE
Remove unnecessary normalization of values in the body index image

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.cpp
@@ -348,9 +348,6 @@ void AzureKinectCameraInput::RunBodyIndexLoop()
 
             bodyMaskBuffer = reinterpret_cast<uint16_t*>(k4a_image_get_buffer(_transformedBodyMaskImage));
 
-            // Set transformed body mask buffer to 1 where bodies are not recognized  
-            SetTransformedBodyMaskBuffer(bodyMaskBuffer, height * width);
-
             // Stage the body mask image, and then end the WritingBodyMask state.
             // This will transition the frame to the Staged state.
             int frameIndex = _currentBodyMaskFrameIndex % MAX_NUM_CACHED_BUFFERS;
@@ -387,17 +384,6 @@ void AzureKinectCameraInput::SetBodyMaskBuffer(uint16_t* bodyMaskBuffer, uint8_t
         else
         {
             bodyMaskBuffer[i] = 0;
-        }
-    }
-}
-
-void AzureKinectCameraInput::SetTransformedBodyMaskBuffer(uint16_t* transformedBodyMaskBuffer, int bufferSize)
-{
-    for (int i = 0; i < bufferSize; i++)
-    {
-        if (transformedBodyMaskBuffer[i] > 0)
-        {
-            transformedBodyMaskBuffer[i] = 1;
         }
     }
 }

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.h
@@ -82,7 +82,6 @@ private:
 
     void ReleaseBodyIndexMap(k4abt_frame_t bodyFrame, k4a_image_t bodyIndexMap);
     void SetBodyMaskBuffer(uint16_t* bodyMaskBuffer, uint8_t* bodyIndexBuffer, int bufferSize);
-    void SetTransformedBodyMaskBuffer(uint16_t* transformedBodyMaskBuffer, int bufferSize);
 
     k4abt_tracker_t _k4abtTracker;
     k4abt_tracker_configuration_t _tracker_config = K4ABT_TRACKER_CONFIG_DEFAULT;


### PR DESCRIPTION
The shaders used by the compositor only care if the values in the body index image are zero or nonzero currently, and so it's not necessary to normalize the values to be only 0 or 1. This saves CPU time each frame that is currently spend unnecessarily adjusting these values.