### PR TITLE
Fix issues with namespaces when building with newer versions of MRTK/the .net winrt dll

### DIFF
--- a/src/SpectatorView.Unity/Assets/PhotoCapture/Scripts/HoloLensCamera.cs
+++ b/src/SpectatorView.Unity/Assets/PhotoCapture/Scripts/HoloLensCamera.cs
@@ -1333,7 +1333,7 @@ namespace Microsoft.MixedReality.PhotoCapture
             }
         }
 
-        private CameraIntrinsics ConvertIntrinsics(Windows.Media.Devices.Core.CameraIntrinsics mediaFrameIntrinsics)
+        private CameraIntrinsics ConvertIntrinsics(global::Windows.Media.Devices.Core.CameraIntrinsics mediaFrameIntrinsics)
         {
             CameraIntrinsics intrinsics = null;
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Calibration/CalibrationDataHelper.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Calibration/CalibrationDataHelper.cs
@@ -276,7 +276,7 @@ namespace Microsoft.MixedReality.SpectatorView
 #if UNITY_EDITOR || UNITY_STANDALONE
             return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 #elif UNITY_WSA
-            return Windows.Storage.KnownFolders.DocumentsLibrary.Path;
+            return global::Windows.Storage.KnownFolders.DocumentsLibrary.Path;
 #else
             return string.Empty;
 #endif

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/ArUcoMarkerVisualDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/MarkerVisual/ArUcoMarkerVisualDetectorSpatialLocalizer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.SpectatorView
             get
             {
 #if UNITY_WSA && !UNITY_EDITOR
-                return Windows.ApplicationModel.Package.Current.Id.Architecture == Windows.System.ProcessorArchitecture.X86;
+                return global::Windows.ApplicationModel.Package.Current.Id.Architecture == global::Windows.System.ProcessorArchitecture.X86;
 #elif UNITY_EDITOR
                 return true;
 #else

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/ArUcoMarkerDetectorSpatialLocalizer.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/SpatialAlignment/PhysicalMarker/ArUcoMarkerDetectorSpatialLocalizer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 // We return true for the editor so that this localizer registers as available for video camera compositing scenarios.
                 return true;
 #elif UNITY_WSA
-                return Windows.ApplicationModel.Package.Current.Id.Architecture == Windows.System.ProcessorArchitecture.X86;
+                return global::Windows.ApplicationModel.Package.Current.Id.Architecture == global::Windows.System.ProcessorArchitecture.X86;
 #else
                 return false;
 #endif


### PR DESCRIPTION
MRTK started using a .net winrt mixed reality dll that causes errors for some types that aren't included in the dll. This change fixes those issues and unblocks wsa player builds.