### PR TITLE
Keep camera mounted headset on when the holographic camera application is running

### DIFF
--- a/src/HolographicCamera.Unity/Assets/HolographicCamera/Scenes/HolographicCamera.unity
+++ b/src/HolographicCamera.Unity/Assets/HolographicCamera/Scenes/HolographicCamera.unity
@@ -220,6 +220,49 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 1460904457943886366, guid: 69cb88afa41c33e4cbb6993b2b3e54ca, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 69cb88afa41c33e4cbb6993b2b3e54ca, type: 3}
+--- !u!1 &928699400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 928699402}
+  - component: {fileID: 928699401}
+  m_Layer: 0
+  m_Name: KeepDeviceActive
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &928699401
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928699400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c005024b31b71740a7f296b17b776c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &928699402
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928699400}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1530402592
 GameObject:
   m_ObjectHideFlags: 0

--- a/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs
+++ b/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs
@@ -59,7 +59,6 @@ public class KeepDeviceActive : MonoBehaviour
                         // the screen is guaranteed not to turn off automatically due to user inactivity. 
                         displayRequest.RequestActive();
                     Debug.Log("Display request activated. Device won't go inactive until closing this scene.");
-                    displayRequestSucceeded = true;
                 }
                 catch (Exception e)
                 {

--- a/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs
+++ b/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
 
 #if UNITY_WSA && WINDOWS_UWP
     using System;

--- a/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs
+++ b/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs
@@ -1,0 +1,72 @@
+﻿using UnityEngine;
+
+#if UNITY_WSA && WINDOWS_UWP
+    using System;
+    using Windows.System.Display;
+#endif
+
+public class KeepDeviceActive : MonoBehaviour
+{
+#if UNITY_WSA && WINDOWS_UWP
+    private static DisplayRequest displayRequest;
+#endif
+
+    private void Start()
+    {
+        CreateDisplayRequest();
+    }
+
+    private void OnDestroy()
+    {
+#if UNITY_WSA && WINDOWS_UWP
+        if (displayRequest != null)
+        {
+            try
+            {
+                displayRequest.RequestRelease();
+                Debug.Log("Display request released.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Error releasing display request: {e.Message}");
+            }
+        }
+#endif
+    }
+
+    private void CreateDisplayRequest()
+    {
+#if UNITY_WSA && WINDOWS_UWP
+        UnityEngine.WSA.Application.InvokeOnUIThread(() =>
+        {
+            if (displayRequest == null)
+            {
+                try
+                {
+                    displayRequest = new DisplayRequest();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"Error creating display request: {e.Message}");
+                }
+            }
+
+            if (displayRequest != null)
+            {
+                try
+                {
+                        // This call activates a display-required request. If successful,  
+                        // the screen is guaranteed not to turn off automatically due to user inactivity. 
+                        displayRequest.RequestActive();
+                    Debug.Log("Display request activated. Device won't go inactive until closing this scene.");
+                    displayRequestSucceeded = true;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"Display request failed: {e.Message}");
+                }
+            }
+        }, true);
+#endif
+    }
+}

--- a/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs.meta
+++ b/src/HolographicCamera.Unity/Assets/HolographicCamera/Scripts/KeepDeviceActive.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c005024b31b71740a7f296b17b776c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change fixes the following issue:
https://github.com/microsoft/MixedReality-SpectatorView/issues/314

We now have a monobehaviour/script in the HolographicCamera scene that makse sure the headset stays on while the application is running.