### PR TITLE
Fix crash when k4a_device_open fails

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/AzureKinectCameraInput.cpp
@@ -35,15 +35,15 @@ AzureKinectCameraInput::AzureKinectCameraInput(k4a_depth_mode_t depthMode, bool 
     , _k4abtTracker(nullptr)
 #endif
 {
+    for (int i = 0; i < MAX_NUM_CACHED_BUFFERS; i++)
+    {
+        _cameraFrames[i] = new AzureKinectCameraFrame(captureDepth, captureBodyMask);
+    }
+
     if (K4A_RESULT_SUCCEEDED != k4a_device_open(K4A_DEVICE_DEFAULT, &_k4aDevice))
     {
         OutputDebugString(L"Failed to open AzureKinect device");
         goto FailedExit;
-    }
-
-    for (int i = 0; i < MAX_NUM_CACHED_BUFFERS; i++)
-    {
-        _cameraFrames[i] = new AzureKinectCameraFrame(captureDepth, captureBodyMask);
     }
 
     _config.color_format = K4A_IMAGE_FORMAT_COLOR_BGRA32;


### PR DESCRIPTION
When `k4a_device_open` fails, the `_cameraFrames` array was never initialized, so the Unity Editor crashes in the `UpdateSRVs` method. When an early-return is added there it just crashes in the destructor of `AzureKinectCameraFrame` where it is not as easy to add such an early-return.

Instead I moved the initialization of the array so it is always initialized, with this I could not reproduce this crash.