### PR TITLE
Feature: Integrated Device Portal

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scenes/SpectatorViewCompositor.unity
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scenes/SpectatorViewCompositor.unity
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -87,7 +94,8 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -247,9 +255,10 @@ Camera:
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -298,11 +307,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 8188703494409108216, guid: 87d0c9d301bd81549ab69326b9ea4695,
-        type: 3}
-      propertyPath: m_Name
-      value: SpectatorView.Compositor
-      objectReference: {fileID: 0}
     - target: {fileID: 7614939800065736745, guid: 87d0c9d301bd81549ab69326b9ea4695,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -357,6 +361,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8188703494409108216, guid: 87d0c9d301bd81549ab69326b9ea4695,
+        type: 3}
+      propertyPath: m_Name
+      value: SpectatorView.Compositor
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 87d0c9d301bd81549ab69326b9ea4695, type: 3}

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -610,7 +610,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     case DevicePortalState.Connecting:
                         stateText = "<color=silver>Connecting...</color>";
                         buttonText = "Cancel";
-                        onPressButton = devicePortal.Cancel;
+                        onPressButton = devicePortal.CancelConnect;
                         break;
 
                     case DevicePortalState.NotStarted:
@@ -635,7 +635,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     case DevicePortalState.Starting:
                         stateText = "<color=orange>Starting...</color>";
                         buttonText = "Cancel";
-                        onPressButton = devicePortal.Cancel;
+                        canPressButton = false;
                         break;
 
                     case DevicePortalState.Stopping:

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -670,6 +670,9 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                         }
                     }
 
+                    GUI.enabled = false;
+                    EditorGUILayout.TextField("IP address", holographicCameraIPAddress);
+
                     GUI.enabled = prevEnabled && devicePortal.State == DevicePortalState.NotConnected;
                     devicePortalUser = EditorGUILayout.TextField("Username", devicePortalUser);
                     devicePortalPassword = EditorGUILayout.PasswordField("Password", devicePortalPassword);

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -31,17 +31,22 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         private bool colorCorrectionFoldout;
         private bool hologramSettingsFoldout;
         private bool occlusionSettingsFoldout;
+        private bool devicePortalFoldout;
 
         private float hologramAlpha;
 
         private float statisticsUpdateTimeSeconds = 0.0f;
         private string appIPAddress;
+        private string devicePortalUser;
+        private string devicePortalPassword = "";
+        private bool devicePortalAutoConnect = true;
 
         private bool? isAzureKinectBodyTrackingSdkInstalledInUnity;
         private static readonly string[] azureKinectBodyTrackingSdkComponents = new[] { "onnxruntime.dll", "dnn_model_2_0.onnx", "cudnn64_7.dll", "cublas64_100.dll", "cudart64_100.dll" };
 
         private static string holographicCameraIPAddressKey = $"{nameof(CompositorWindow)}.{nameof(holographicCameraIPAddress)}";
         private static string appIPAddressKey = $"{nameof(CompositorWindow)}.{nameof(appIPAddress)}";
+        private static string devicePortalUserKey = $"{nameof(CompositorWindow)}.{nameof(devicePortalUser)}";
 
         [MenuItem("Spectator View/Compositor", false, 0)]
         public static void ShowCompositorWindow()
@@ -61,6 +66,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
             holographicCameraIPAddress = PlayerPrefs.GetString(holographicCameraIPAddressKey, "localhost");
             appIPAddress = PlayerPrefs.GetString(appIPAddressKey, "localhost");
+            devicePortalUser = PlayerPrefs.GetString(devicePortalUserKey);
         }
 
         protected override void OnDisable()
@@ -69,6 +75,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
             PlayerPrefs.SetString(holographicCameraIPAddressKey, holographicCameraIPAddress);
             PlayerPrefs.SetString(appIPAddressKey, appIPAddress);
+            PlayerPrefs.SetString(devicePortalUserKey, devicePortalUser);
             PlayerPrefs.Save();
         }
 
@@ -83,6 +90,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 ColorCorrectionGUI();
                 HologramSettingsGUI();
                 CompositorStatsGUI();
+                DevicePortalGUI();
             }
             EditorGUILayout.EndScrollView();
         }
@@ -570,6 +578,105 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
                     RenderTitle("Compositor is not running, no statistics available", Color.green);
                 }
+            }
+        }
+
+        private void DevicePortalGUI()
+        {
+            devicePortalFoldout = EditorGUILayout.Foldout(devicePortalFoldout, "Device Portal");
+            if (devicePortalFoldout)
+            {
+                EditorGUILayout.BeginVertical("Box");
+                DevicePortalConnection devicePortal = GetDevicePortal();
+                bool prevEnabled = GUI.enabled;
+                GUILayout.Label("DevicePortal", EditorStyles.boldLabel);
+
+                string stateText, buttonText;
+                bool canPressButton = true;
+                Action onPressButton = () => { };
+                switch(devicePortal.State)
+                {
+                    case DevicePortalState.NotConnected:
+                        stateText = "<color=silver>Not Connected</color>";
+                        canPressButton =
+                            devicePortalUser.Trim() != "" &&
+                            devicePortalPassword != "" &&
+                            IPAddress.TryParse(holographicCameraIPAddress, out var _) &&
+                            EditorApplication.isPlaying;
+                        buttonText = "Connect";
+                        onPressButton = () => devicePortal.StartConnect(holographicCameraIPAddress, devicePortalUser, devicePortalPassword);
+                        break;
+
+                    case DevicePortalState.Connecting:
+                        stateText = "<color=silver>Connecting...</color>";
+                        buttonText = "Cancel";
+                        onPressButton = devicePortal.Cancel;
+                        break;
+
+                    case DevicePortalState.NotStarted:
+                        stateText = "<color=red>App was not started</color>";
+                        canPressButton = devicePortal.IsAppInstalled;
+                        buttonText = "Start App";
+                        onPressButton = devicePortal.StartApp;
+                        break;
+
+                    case DevicePortalState.NotRunning:
+                        stateText = "<color=orange>Started, but not running</color>";
+                        buttonText = "Stop App";
+                        onPressButton = devicePortal.StopApp;
+                        break;
+
+                    case DevicePortalState.Running:
+                        stateText = "<color=green>Running</color>";
+                        buttonText = "Stop App";
+                        onPressButton = devicePortal.StopApp;
+                        break;
+
+                    case DevicePortalState.Starting:
+                        stateText = "<color=orange>Starting...</color>";
+                        buttonText = "Cancel";
+                        onPressButton = devicePortal.Cancel;
+                        break;
+
+                    case DevicePortalState.Stopping:
+                        stateText = "<color=orange>Stopping...</color>";
+                        canPressButton = false;
+                        buttonText = "Cancel";
+                        break;
+
+                    default:
+                        stateText = "<color=magenta>I don't know</color>";
+                        canPressButton = true;
+                        buttonText = "Disconnect";
+                        onPressButton = devicePortal.Disconnect;
+                        break;
+                }
+                GUIStyle appStateStyle = EditorStyles.textField;
+                appStateStyle.richText = true;
+                appStateStyle.fontStyle = FontStyle.Bold;
+                GUILayout.BeginHorizontal();
+                GUI.enabled = false;
+                EditorGUILayout.TextField("State", stateText, appStateStyle);
+                GUI.enabled = prevEnabled && canPressButton;
+                if (GUILayout.Button(buttonText, GUILayout.Width(connectAndDisconnectButtonWidth)))
+                    onPressButton();
+                GUILayout.EndHorizontal();
+
+                GUI.enabled = prevEnabled && devicePortal.State == DevicePortalState.NotConnected;
+                devicePortalUser = EditorGUILayout.TextField("Username", devicePortalUser);
+                devicePortalPassword = EditorGUILayout.PasswordField("Password", devicePortalPassword);
+                const string autoConnectTooltip = "Automatically connects/disconnects the holographic camera upon app starting/stopping.";
+                devicePortalAutoConnect = EditorGUILayout.Toggle(new GUIContent("Auto Connect", autoConnectTooltip), devicePortalAutoConnect);
+                EditorGUILayout.Space();
+
+                GUI.enabled = prevEnabled && devicePortal.IsConnected;
+                GUILayout.Label("Health", EditorStyles.boldLabel);
+                EditorGUILayout.FloatField(new GUIContent("CPU", "The amount of CPU used by the app"), devicePortal.CPUUsage);
+                EditorGUILayout.TextField(new GUIContent("RAM", "The amount of RAM used by the app"), $"{devicePortal.WorkingSet / 1024 / 1024}MiB");
+                EditorGUILayout.TextField("Battery", $"{(int)(devicePortal.BatteryLevel * 100)}% {(devicePortal.IsPowered ? "- Powered" : "")}");
+
+                GUI.enabled = prevEnabled;
+                EditorGUILayout.EndVertical();
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -604,8 +604,8 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                         case DevicePortalState.NotConnected:
                             stateText = "<color=silver>Not Connected</color>";
                             canPressButton =
-                                devicePortalUser.Trim() != "" &&
-                                devicePortalPassword != "" &&
+                                !string.IsNullOrWhiteSpace(devicePortalUser) &&
+                                !string.IsNullOrEmpty(devicePortalPassword) &&
                                 IPAddress.TryParse(holographicCameraIPAddress, out var _) &&
                                 EditorApplication.isPlaying;
                             buttonText = "Connect";

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -582,11 +582,16 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
         private void DevicePortalGUI()
         {
+            DevicePortalConnection devicePortal = GetDevicePortal();
+            if (devicePortal == null)
+            {
+                return;
+            }
+
             devicePortalFoldout = EditorGUILayout.Foldout(devicePortalFoldout, "Device Portal");
             if (devicePortalFoldout)
             {
                 EditorGUILayout.BeginVertical("Box");
-                DevicePortalConnection devicePortal = GetDevicePortal();
                 bool prevEnabled = GUI.enabled;
                 GUILayout.Label("DevicePortal", EditorStyles.boldLabel);
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -668,6 +668,12 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                         {
                             onPressButton();
                         }
+
+                        GUI.enabled = prevEnabled;
+                        if (devicePortal.IsConnected &&GUILayout.Button("Disconnect", GUILayout.Width(connectAndDisconnectButtonWidth)))
+                        {
+                            devicePortal.Disconnect();
+                        }
                     }
 
                     GUI.enabled = false;

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -39,7 +39,6 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         private string appIPAddress;
         private string devicePortalUser;
         private string devicePortalPassword = "";
-        private bool devicePortalAutoConnect = true;
 
         private bool? isAzureKinectBodyTrackingSdkInstalledInUnity;
         private static readonly string[] azureKinectBodyTrackingSdkComponents = new[] { "onnxruntime.dll", "dnn_model_2_0.onnx", "cudnn64_7.dll", "cublas64_100.dll", "cudart64_100.dll" };
@@ -665,8 +664,6 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                 GUI.enabled = prevEnabled && devicePortal.State == DevicePortalState.NotConnected;
                 devicePortalUser = EditorGUILayout.TextField("Username", devicePortalUser);
                 devicePortalPassword = EditorGUILayout.PasswordField("Password", devicePortalPassword);
-                const string autoConnectTooltip = "Automatically connects/disconnects the holographic camera upon app starting/stopping.";
-                devicePortalAutoConnect = EditorGUILayout.Toggle(new GUIContent("Auto Connect", autoConnectTooltip), devicePortalAutoConnect);
                 EditorGUILayout.Space();
 
                 GUI.enabled = prevEnabled && devicePortal.IsConnected;

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -591,94 +591,98 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             devicePortalFoldout = EditorGUILayout.Foldout(devicePortalFoldout, "Device Portal");
             if (devicePortalFoldout)
             {
-                EditorGUILayout.BeginVertical("Box");
-                bool prevEnabled = GUI.enabled;
-                GUILayout.Label("DevicePortal", EditorStyles.boldLabel);
-
-                string stateText, buttonText;
-                bool canPressButton = true;
-                Action onPressButton = () => { };
-                switch(devicePortal.State)
+                using (new EditorGUILayout.VerticalScope("Box"))
                 {
-                    case DevicePortalState.NotConnected:
-                        stateText = "<color=silver>Not Connected</color>";
-                        canPressButton =
-                            devicePortalUser.Trim() != "" &&
-                            devicePortalPassword != "" &&
-                            IPAddress.TryParse(holographicCameraIPAddress, out var _) &&
-                            EditorApplication.isPlaying;
-                        buttonText = "Connect";
-                        onPressButton = () => devicePortal.StartConnect(holographicCameraIPAddress, devicePortalUser, devicePortalPassword);
-                        break;
+                    bool prevEnabled = GUI.enabled;
+                    GUILayout.Label("DevicePortal", EditorStyles.boldLabel);
 
-                    case DevicePortalState.Connecting:
-                        stateText = "<color=silver>Connecting...</color>";
-                        buttonText = "Cancel";
-                        onPressButton = devicePortal.CancelConnect;
-                        break;
+                    string stateText, buttonText;
+                    bool canPressButton = true;
+                    Action onPressButton = () => { };
+                    switch (devicePortal.State)
+                    {
+                        case DevicePortalState.NotConnected:
+                            stateText = "<color=silver>Not Connected</color>";
+                            canPressButton =
+                                devicePortalUser.Trim() != "" &&
+                                devicePortalPassword != "" &&
+                                IPAddress.TryParse(holographicCameraIPAddress, out var _) &&
+                                EditorApplication.isPlaying;
+                            buttonText = "Connect";
+                            onPressButton = () => devicePortal.StartConnect(holographicCameraIPAddress, devicePortalUser, devicePortalPassword);
+                            break;
 
-                    case DevicePortalState.NotStarted:
-                        stateText = "<color=red>App was not started</color>";
-                        canPressButton = devicePortal.IsAppInstalled;
-                        buttonText = "Start App";
-                        onPressButton = devicePortal.StartApp;
-                        break;
+                        case DevicePortalState.Connecting:
+                            stateText = "<color=silver>Connecting...</color>";
+                            buttonText = "Cancel";
+                            onPressButton = devicePortal.CancelConnect;
+                            break;
 
-                    case DevicePortalState.NotRunning:
-                        stateText = "<color=orange>Started, but not running</color>";
-                        buttonText = "Stop App";
-                        onPressButton = devicePortal.StopApp;
-                        break;
+                        case DevicePortalState.NotStarted:
+                            stateText = "<color=red>App was not started</color>";
+                            canPressButton = devicePortal.IsAppInstalled;
+                            buttonText = "Start App";
+                            onPressButton = devicePortal.StartApp;
+                            break;
 
-                    case DevicePortalState.Running:
-                        stateText = "<color=green>Running</color>";
-                        buttonText = "Stop App";
-                        onPressButton = devicePortal.StopApp;
-                        break;
+                        case DevicePortalState.NotRunning:
+                            stateText = "<color=orange>Started, but not running</color>";
+                            buttonText = "Stop App";
+                            onPressButton = devicePortal.StopApp;
+                            break;
 
-                    case DevicePortalState.Starting:
-                        stateText = "<color=orange>Starting...</color>";
-                        buttonText = "Cancel";
-                        canPressButton = false;
-                        break;
+                        case DevicePortalState.Running:
+                            stateText = "<color=green>Running</color>";
+                            buttonText = "Stop App";
+                            onPressButton = devicePortal.StopApp;
+                            break;
 
-                    case DevicePortalState.Stopping:
-                        stateText = "<color=orange>Stopping...</color>";
-                        canPressButton = false;
-                        buttonText = "Cancel";
-                        break;
+                        case DevicePortalState.Starting:
+                            stateText = "<color=orange>Starting...</color>";
+                            buttonText = "Cancel";
+                            canPressButton = false;
+                            break;
 
-                    default:
-                        stateText = "<color=magenta>I don't know</color>";
-                        canPressButton = true;
-                        buttonText = "Disconnect";
-                        onPressButton = devicePortal.Disconnect;
-                        break;
+                        case DevicePortalState.Stopping:
+                            stateText = "<color=orange>Stopping...</color>";
+                            canPressButton = false;
+                            buttonText = "Cancel";
+                            break;
+
+                        default:
+                            stateText = "<color=magenta>I don't know</color>";
+                            canPressButton = true;
+                            buttonText = "Disconnect";
+                            onPressButton = devicePortal.Disconnect;
+                            break;
+                    }
+                    GUIStyle appStateStyle = EditorStyles.textField;
+                    appStateStyle.richText = true;
+                    appStateStyle.fontStyle = FontStyle.Bold;
+                    using (new GUILayout.HorizontalScope())
+                    {
+                        GUI.enabled = false;
+                        EditorGUILayout.TextField("State", stateText, appStateStyle);
+                        GUI.enabled = prevEnabled && canPressButton;
+                        if (GUILayout.Button(buttonText, GUILayout.Width(connectAndDisconnectButtonWidth)))
+                        {
+                            onPressButton();
+                        }
+                    }
+
+                    GUI.enabled = prevEnabled && devicePortal.State == DevicePortalState.NotConnected;
+                    devicePortalUser = EditorGUILayout.TextField("Username", devicePortalUser);
+                    devicePortalPassword = EditorGUILayout.PasswordField("Password", devicePortalPassword);
+                    EditorGUILayout.Space();
+
+                    GUI.enabled = prevEnabled && devicePortal.IsConnected;
+                    GUILayout.Label("Health", EditorStyles.boldLabel);
+                    EditorGUILayout.FloatField(new GUIContent("CPU", "The amount of CPU used by the app"), devicePortal.CPUUsage);
+                    EditorGUILayout.TextField(new GUIContent("RAM", "The amount of RAM used by the app"), $"{devicePortal.WorkingSet / 1024 / 1024}MiB");
+                    EditorGUILayout.TextField("Battery", $"{(int)(devicePortal.BatteryLevel * 100)}% {(devicePortal.IsPowered ? "- Powered" : "")}");
+
+                    GUI.enabled = prevEnabled;
                 }
-                GUIStyle appStateStyle = EditorStyles.textField;
-                appStateStyle.richText = true;
-                appStateStyle.fontStyle = FontStyle.Bold;
-                GUILayout.BeginHorizontal();
-                GUI.enabled = false;
-                EditorGUILayout.TextField("State", stateText, appStateStyle);
-                GUI.enabled = prevEnabled && canPressButton;
-                if (GUILayout.Button(buttonText, GUILayout.Width(connectAndDisconnectButtonWidth)))
-                    onPressButton();
-                GUILayout.EndHorizontal();
-
-                GUI.enabled = prevEnabled && devicePortal.State == DevicePortalState.NotConnected;
-                devicePortalUser = EditorGUILayout.TextField("Username", devicePortalUser);
-                devicePortalPassword = EditorGUILayout.PasswordField("Password", devicePortalPassword);
-                EditorGUILayout.Space();
-
-                GUI.enabled = prevEnabled && devicePortal.IsConnected;
-                GUILayout.Label("Health", EditorStyles.boldLabel);
-                EditorGUILayout.FloatField(new GUIContent("CPU", "The amount of CPU used by the app"), devicePortal.CPUUsage);
-                EditorGUILayout.TextField(new GUIContent("RAM", "The amount of RAM used by the app"), $"{devicePortal.WorkingSet / 1024 / 1024}MiB");
-                EditorGUILayout.TextField("Battery", $"{(int)(devicePortal.BatteryLevel * 100)}% {(devicePortal.IsPowered ? "- Powered" : "")}");
-
-                GUI.enabled = prevEnabled;
-                EditorGUILayout.EndVertical();
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -472,7 +472,9 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
         protected DevicePortalConnection GetDevicePortal()
         {
             if (cachedDevicePortal == null)
+            {
                 cachedDevicePortal = FindObjectOfType<DevicePortalConnection>();
+            }
             return cachedDevicePortal;
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindowBase.cs
@@ -35,6 +35,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
         private CompositionManager cachedCompositionManager;
         private HolographicCameraObserver cachedHolographicCameraObserver;
+        private DevicePortalConnection cachedDevicePortal;
 
         protected int renderFrameWidth;
         protected int renderFrameHeight;
@@ -466,6 +467,13 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
             {
                 return null;
             }
+        }
+
+        protected DevicePortalConnection GetDevicePortal()
+        {
+            if (cachedDevicePortal == null)
+                cachedDevicePortal = FindObjectOfType<DevicePortalConnection>();
+            return cachedDevicePortal;
         }
 
         protected SpatialCoordinateSystemParticipant GetSpatialCoordinateSystemParticipant(DeviceInfoObserver device)

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/SpectatorView.Compositor.prefab
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Prefabs/SpectatorView.Compositor.prefab
@@ -159,6 +159,52 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7b4927568ed4b68488df1f3f2432009e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &3486000859256592713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 349523541584959630}
+  - component: {fileID: 2198350781126293163}
+  m_Layer: 0
+  m_Name: DevicePortal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &349523541584959630
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3486000859256592713}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7614939800065736745}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2198350781126293163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3486000859256592713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c030abfceaff0641944519cdcf69bf9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthCheckInterval: 5
+  appStartCheckInterval: 1
+  appStartMaxTries: 10
 --- !u!1 &4951648750919070004
 GameObject:
   m_ObjectHideFlags: 0
@@ -365,9 +411,10 @@ Camera:
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -565,6 +612,7 @@ Transform:
   - {fileID: 9153189694046729988}
   - {fileID: 3819793112508872898}
   - {fileID: 7946342453098565599}
+  - {fileID: 349523541584959630}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
@@ -61,8 +61,6 @@ namespace Microsoft.MixedReality.SpectatorView
         public int WorkingSet { get; private set; } = 0;
         public float CPUUsage { get; private set; } = 0.0f;
 
-        public DeviceInfoObserver HolographicDeviceInfo { get; set; } = null;
-
         public void StartConnect(string ipAddress, string user, string password)
         {
             async Task Connect()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
@@ -1,0 +1,314 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Networking;
+using System;
+using System.Threading;
+using System.Net;
+using System.Threading.Tasks;
+using System.Collections;
+using System.Text;
+using System.IO;
+
+namespace Microsoft.MixedReality.SpectatorView
+{
+    public enum DevicePortalState
+    {
+        NotConnected,
+        Connecting,
+        NotStarted,
+        NotRunning,
+        Running,
+        Starting,
+        Stopping
+    }
+
+    public class DevicePortalConnection : MonoBehaviour
+    {
+        private const string HolographicCameraAppName = "SpectatorView.HolographicCamera";
+        private const string InfoRoute = "/api/os/info";
+        private const string BatteryRoute = "/api/power/battery";
+        private const string InstalledPackagesRoute = "/api/app/packagemanager/packages";
+        private const string RunningProcessesRoute = "/api/resourcemanager/processes";
+        private const string StartAppRouteBase = "/api/taskmanager/app?appid=";
+        private const string StopAppRouteBase = "/api/taskmanager/app?package=";
+
+        [SerializeField]
+        [Tooltip("Interval in seconds between two health checks")]
+        private float healthCheckInterval = 5.0f;
+        [SerializeField]
+        [Tooltip("Interval in seconds between two checks during app start")]
+        private float appStartCheckInterval = 1.0f;
+        [SerializeField]
+        [Tooltip("Number of checks during app start")]
+        private int appStartMaxTries = 10;
+
+        private string ipAddress;
+        private string authorization;
+        private InstalledPackage? deviceApp;
+        private float lastHealthCheck;
+        private CancellationTokenSource taskCTS = null;
+        private string StartAppRoute => StartAppRouteBase + Uri.EscapeDataString(Convert.ToBase64String(Encoding.UTF8.GetBytes(deviceApp.Value.PackageRelativeId)));
+        private string StopAppRoute => StopAppRouteBase + Uri.EscapeDataString(Convert.ToBase64String(Encoding.UTF8.GetBytes(deviceApp.Value.PackageFullName)));
+
+        public DevicePortalState State { get; private set; } = DevicePortalState.NotConnected;
+        public bool IsConnected => State != DevicePortalState.NotConnected && State != DevicePortalState.Connecting;
+
+        public string DeviceName { get; private set; } = "<unknown>";
+        public bool IsAppInstalled => deviceApp.HasValue;
+        public float BatteryLevel { get; private set; } = 0.0f;
+        public bool IsPowered { get; private set; } = false;
+        public int WorkingSet { get; private set; } = 0;
+        public float CPUUsage { get; private set; } = 0.0f;
+
+        public void StartConnect(string ipAddress, string user, string password)
+        {
+            async Task Connect()
+            {
+                var info = await SendJSONRequest<InfoResponse>(InfoRoute);
+                DeviceName = info.ComputerName;
+
+                var packages = await SendJSONRequest<PackagesResponse>(InstalledPackagesRoute);
+                var optDeviceApp = packages.InstalledPackages?.FirstOrDefault(p => p.Name.Contains(HolographicCameraAppName));
+                if (packages.InstalledPackages == null || optDeviceApp == null || optDeviceApp.Value.PackageFullName == null)
+                {
+                    Debug.LogError("Could not find holographic camera app installed on device");
+                }
+                else
+                {
+                    deviceApp = optDeviceApp.Value;
+                }
+
+                await RunHealthCheck();
+                taskCTS = null;
+            }
+
+            State = DevicePortalState.Connecting;
+            this.ipAddress = ipAddress;
+            // mind the "auto-" prefix to bypass CSRF protection
+            authorization = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("auto-" + user + ":" + password));
+            taskCTS = new CancellationTokenSource();
+            Dispatcher.ScheduleAsync(Connect, taskCTS.Token);
+        }
+
+        public void Cancel()
+        {
+            if (taskCTS != null)
+            {
+                taskCTS.Cancel();
+                State = DevicePortalState.NotConnected;
+            }
+        }
+
+        public void Disconnect()
+        {
+            State = DevicePortalState.NotConnected;
+        }
+
+        public void StartApp()
+        {
+            async Task StartAppAsync()
+            {
+                var request = await SendRequest(StartAppRoute, "POST");
+                if (request.isHttpError || request.isNetworkError)
+                {
+                    Debug.LogError("Could not send a request to start the app: " + request.error);
+                    State = DevicePortalState.NotStarted;
+                    return;
+                }
+
+                for (int i = 0; i < appStartMaxTries; i++)
+                {
+                    await CheckRunningProcess();
+                    if (State == DevicePortalState.Running)
+                        return;
+                    await Task.Delay(TimeSpan.FromSeconds(appStartCheckInterval));
+                }
+
+                Debug.LogError("Could not start the app");
+            }
+
+            if (!IsAppInstalled)
+            {
+                Debug.LogError("App cannot be started because it is not installed");
+                return;
+            }
+            if (State != DevicePortalState.NotStarted)
+            {
+                Debug.LogError($"Unexpected state for starting the app: {State}");
+                return;
+            }
+            State = DevicePortalState.Starting;
+            taskCTS = new CancellationTokenSource();
+            Dispatcher.ScheduleAsync(StartAppAsync, taskCTS.Token);
+        }
+
+        public void StopApp()
+        {
+            async Task StopAppAsync()
+            {
+                var request = await SendRequest(StopAppRoute, "DELETE");
+                if (request.isNetworkError || request.isHttpError)
+                {
+                    Debug.LogError($"Could not send a request to stop the app: {request.error}");
+                    return;
+                }
+
+                for (int i = 0; i < appStartMaxTries; i++)
+                {
+                    await CheckRunningProcess();
+                    if (State != DevicePortalState.Running && State != DevicePortalState.NotRunning)
+                        return;
+                    State = DevicePortalState.Stopping; // stopping takes a while and changes from running to not running to not started
+                    await Task.Delay(TimeSpan.FromSeconds(appStartCheckInterval));
+                }
+
+                Debug.LogError("Could not stop the app");
+            }
+
+            if (!IsAppInstalled)
+            {
+                Debug.LogError("App cannot be stopped because it is not installed");
+                return;
+            }
+            if (State != DevicePortalState.NotRunning && State != DevicePortalState.Running)
+            {
+                Debug.LogError($"Unexpected state for stopping the app: {State}");
+                return;
+            }
+            State = DevicePortalState.Stopping;
+            taskCTS = new CancellationTokenSource();
+            Dispatcher.ScheduleAsync(StopAppAsync, taskCTS.Token);
+        }
+
+        private void Update()
+        {
+            if (!IsConnected || State == DevicePortalState.Starting || State == DevicePortalState.Stopping)
+                return;
+
+            if (Time.time - lastHealthCheck >= healthCheckInterval)
+            {
+                var cts = new CancellationTokenSource();
+                Dispatcher.ScheduleAsync(RunHealthCheck, cts.Token);
+            }
+        }
+
+        private async Task RunHealthCheck()
+        {
+            lastHealthCheck = Time.time;
+
+            var battery = await SendJSONRequest<BatteryResponse>(BatteryRoute);
+            IsPowered = battery.AcOnline;
+            BatteryLevel = battery.Level;
+
+            await CheckRunningProcess();
+        }
+
+        private async Task CheckRunningProcess()
+        {
+            if (deviceApp == null)
+            {
+                State = DevicePortalState.NotStarted;
+                return;
+            }
+
+            var processes = await SendJSONRequest<ProcessesResponse>(RunningProcessesRoute);
+            var optProcess = processes.Processes?.FirstOrDefault(
+                p => p.PackageFullName == deviceApp.Value.PackageFullName && p.ImageName != "RuntimeBroker.exe");
+            if (processes.Processes == null || optProcess == null || optProcess.Value.PackageFullName == null)
+            {
+                State = DevicePortalState.NotStarted;
+                return;
+            }
+            State = optProcess.Value.IsRunning ? DevicePortalState.Running : DevicePortalState.NotRunning;
+            CPUUsage = optProcess.Value.CPUUsage;
+            WorkingSet = optProcess.Value.PrivateWorkingSet;
+        }
+
+        private async Task<UnityWebRequest> SendRequest(string route, string method = "GET")
+        {
+            var request = new UnityWebRequest($"https://{ipAddress}{route}", method);
+            request.SetRequestHeader("authorization", authorization);
+            request.certificateHandler = new DevicePortalCertificateHandler();
+            request.downloadHandler = new DownloadHandlerBuffer();
+            var requestOperation = request.SendWebRequest();
+            if (taskCTS == null)
+                taskCTS = new CancellationTokenSource();
+            await Dispatcher.WhenAsync(() => requestOperation.isDone, taskCTS.Token);
+
+            return request;
+        }
+
+        private async Task<T> SendJSONRequest<T>(string route, string method = "GET")
+        {
+            var request = await SendRequest(route, method);
+
+            if (request.isNetworkError || request.isHttpError)
+            {
+                State = DevicePortalState.NotConnected;
+                var exception = new IOException("Could not send request to device portal: " + request.error);
+                Debug.LogException(exception); // thrown exceptions from tasks are not visible in Unity console 
+                throw exception;
+            }
+            return JsonUtility.FromJson<T>(request.downloadHandler.text);
+        }
+
+        private class DevicePortalCertificateHandler : CertificateHandler
+        {
+            protected override bool ValidateCertificate(byte[] certificateData)
+            {
+                // TODO: Give opportunity for user to provide certificate hash to compare against?
+                return true;
+            }
+        }
+
+#pragma warning disable CS0649 // variable is never assigned (wrong, it is by JsonUtility)
+        [Serializable]
+        private struct InfoResponse
+        {
+            public string ComputerName;
+        }
+
+        [Serializable]
+        private struct InstalledPackage
+        {
+            public string Name;
+            public string PackageFullName;
+            public string PackageRelativeId;
+        }
+
+        [Serializable]
+        private struct PackagesResponse
+        {
+            public InstalledPackage[] InstalledPackages;
+        }
+
+        [Serializable]
+        private struct BatteryResponse
+        {
+            public bool AcOnline;
+            public int MaximumCapacity;
+            public int RemainingCapacity;
+
+            public float Level => MaximumCapacity >= 0
+                ? RemainingCapacity / (float)MaximumCapacity
+                : float.NaN;
+        }
+
+        [Serializable]
+        private struct ProcessesResponse
+        {
+            [Serializable]
+            public struct RunningProcess
+            {
+                public float CPUUsage;
+                public bool IsRunning;
+                public string PackageFullName;
+                public int PrivateWorkingSet;
+                public string ImageName;
+            }
+            public RunningProcess[] Processes;
+        }
+#pragma warning restore CS0649
+    }
+}

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
@@ -1,14 +1,11 @@
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-using UnityEngine.Networking;
 using System;
+using System.Linq;
 using System.Threading;
-using System.Net;
 using System.Threading.Tasks;
-using System.Collections;
 using System.Text;
 using System.IO;
+using UnityEngine;
+using UnityEngine.Networking;
 
 namespace Microsoft.MixedReality.SpectatorView
 {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 using System;
 using System.Linq;
 using System.Threading;
@@ -135,8 +137,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 return;
             }
             State = DevicePortalState.Starting;
-            var cts = new CancellationTokenSource();
-            Dispatcher.ScheduleAsync(StartAppAsync, cts.Token);
+            Dispatcher.ScheduleAsync(StartAppAsync, CancellationToken.None);
         }
 
         public void StopApp()
@@ -173,8 +174,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 return;
             }
             State = DevicePortalState.Stopping;
-            var cts = new CancellationTokenSource();
-            Dispatcher.ScheduleAsync(StopAppAsync, cts.Token);
+            Dispatcher.ScheduleAsync(StopAppAsync, CancellationToken.None);
         }
 
         private void Update()
@@ -186,8 +186,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
             if (Time.time - lastHealthCheck >= healthCheckInterval)
             {
-                var cts = new CancellationTokenSource();
-                Dispatcher.ScheduleAsync(RunHealthCheck, cts.Token);
+                Dispatcher.ScheduleAsync(RunHealthCheck, CancellationToken.None);
             }
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
@@ -72,6 +72,7 @@ namespace Microsoft.MixedReality.SpectatorView
                 if (optDeviceApp?.PackageFullName == null)
                 {
                     Debug.LogError("Could not find holographic camera app installed on device");
+                    deviceApp = null;
                 }
                 else
                 {
@@ -100,6 +101,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
         public void Disconnect()
         {
+            CancelConnect();
             State = DevicePortalState.NotConnected;
         }
 

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
                 var packages = await SendJSONRequest<PackagesResponse>(InstalledPackagesRoute);
                 var optDeviceApp = packages.InstalledPackages?.FirstOrDefault(p => p.Name.Contains(HolographicCameraAppName));
-                if (packages.InstalledPackages == null || optDeviceApp == null || optDeviceApp.Value.PackageFullName == null)
+                if (optDeviceApp?.PackageFullName == null)
                 {
                     Debug.LogError("Could not find holographic camera app installed on device");
                 }
@@ -213,7 +213,7 @@ namespace Microsoft.MixedReality.SpectatorView
             var processes = await SendJSONRequest<ProcessesResponse>(RunningProcessesRoute);
             var optProcess = processes.Processes?.FirstOrDefault(
                 p => p.PackageFullName == deviceApp.Value.PackageFullName && p.ImageName != "RuntimeBroker.exe");
-            if (processes.Processes == null || optProcess == null || optProcess.Value.PackageFullName == null)
+            if (optProcess?.PackageFullName == null)
             {
                 State = DevicePortalState.NotStarted;
                 return;

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs
@@ -183,7 +183,9 @@ namespace Microsoft.MixedReality.SpectatorView
         private void Update()
         {
             if (!IsConnected || State == DevicePortalState.Starting || State == DevicePortalState.Stopping)
+            {
                 return;
+            }
 
             if (Time.time - lastHealthCheck >= healthCheckInterval)
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs.meta
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/DevicePortalConnection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c030abfceaff0641944519cdcf69bf9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![PR-DevicePortal](https://user-images.githubusercontent.com/62652869/82430247-60018500-9a8d-11ea-8e30-aa9b63747c8e.gif)

## Description

These days live demos are mostly done by me juggling many different programs simultaneously 
 (Unity, Hololens App, Teams, OBS, Browser) to finally be able to stream a video signal. One of these programs is the browser as to start/stop the holographic camera app on the Hololens.
With this PR I can now do this directly in the Unity editor removing the need for the browser. Also I added some basic health information so I can judge before/during the demo whether the app is about to crash (using CPU/RAM as indicators) and whether the HL is going to shutdown on me because I forgot to charge it sufficiently beforehand.

I tested this feature with both HL1 and HL2 

## Summary of changes

- A new GameObject with a single component `DevicePortalConnection` in the Compositor prefab that handles the web requests to the DevicePortal
- The UI was added to the `CompositorWindow`