### PR TITLE
Feature: Add low latency mode

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
@@ -294,6 +294,18 @@ int CompositorInterface::GetNumQueuedOutputFrames()
     return 0;
 }
 
+void CompositorInterface::SetOutputLowLatencyMode(bool isEnabled)
+{
+    if (outputFrameProvider != nullptr)
+    {
+        outputFrameProvider->SetOutputLowLatencyMode(isEnabled);
+    }
+    else if (frameProvider != nullptr)
+    {
+        frameProvider->SetOutputLowLatencyMode(isEnabled);
+    }
+}
+
 void CompositorInterface::SetCompositeFrameIndex(int index)
 {
     compositeFrameIndex = index;

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
@@ -294,15 +294,15 @@ int CompositorInterface::GetNumQueuedOutputFrames()
     return 0;
 }
 
-void CompositorInterface::SetOutputLowLatencyMode(bool isEnabled)
+void CompositorInterface::SetLatencyPreference(float latencyPreference)
 {
+    if (frameProvider != nullptr)
+    {
+        frameProvider->SetLatencyPreference(latencyPreference);
+    }
     if (outputFrameProvider != nullptr)
     {
-        outputFrameProvider->SetOutputLowLatencyMode(isEnabled);
-    }
-    else if (frameProvider != nullptr)
-    {
-        frameProvider->SetOutputLowLatencyMode(isEnabled);
+        outputFrameProvider->SetLatencyPreference(latencyPreference);
     }
 }
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
@@ -69,6 +69,7 @@ public:
     DLLEXPORT int GetCaptureFrameIndex();
     DLLEXPORT int GetPixelChange(int frame);
     DLLEXPORT int GetNumQueuedOutputFrames();
+    DLLEXPORT void SetOutputLowLatencyMode(bool isEnabled);
 
     DLLEXPORT void SetCompositeFrameIndex(int index);
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
@@ -69,7 +69,7 @@ public:
     DLLEXPORT int GetCaptureFrameIndex();
     DLLEXPORT int GetPixelChange(int frame);
     DLLEXPORT int GetNumQueuedOutputFrames();
-    DLLEXPORT void SetOutputLowLatencyMode(bool isEnabled);
+    DLLEXPORT void SetLatencyPreference(float latencyPreference);
 
     DLLEXPORT void SetCompositeFrameIndex(int index);
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
@@ -288,9 +288,10 @@ public:
 
     }
 
-    void SetLowLatencyMode(bool isEnabled)
+    void SetLatencyPreference(float latencyPreference)
     {
-        minFramesQueued = isEnabled ? 1 : defaultMinFramesQueued;
+        minFramesQueued = 1 + latencyPreference * (minFramesQueued - 1);
+        minFramesQueued = min(1UL, max(minFramesQueued, static_cast<unsigned long>(MAX_NUM_OUTPUT_FRAMES)));
     }
 
     HRESULT	STDMETHODCALLTYPE ScheduledFrameCompleted(IDeckLinkVideoFrame* completedFrame, BMDOutputFrameCompletionResult result)
@@ -742,9 +743,9 @@ int DeckLinkDevice::GetNumQueuedOutputFrames()
     return s_outputScheduler.framesQueued;
 }
 
-void DeckLinkDevice::SetOutputLowLatencyMode(bool isEnabled)
+void DeckLinkDevice::SetLatencyPreference(float latencyPreference)
 {
-    s_outputScheduler.SetLowLatencyMode(isEnabled);
+    s_outputScheduler.SetLatencyPreference(latencyPreference);
 }
 
 void DeckLinkDevice::Update(int compositeFrameIndex)

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
@@ -51,6 +51,8 @@ public:
 #define MAX_NUM_OUTPUT_FRAMES 20
     IDeckLinkMutableVideoFrame* outputVideoFrames[MAX_NUM_OUTPUT_FRAMES];
     int outputWriteIndex = 0;
+    const unsigned long defaultMinFramesQueued = MAX_NUM_OUTPUT_FRAMES - 4;
+    unsigned long minFramesQueued = defaultMinFramesQueued;
 
     OutputScheduler()
     {
@@ -219,7 +221,7 @@ public:
         if (started)
         {
             //Try to fill the queue back up
-            if (framesQueued < MAX_NUM_OUTPUT_FRAMES - 5)
+            if (framesQueued < minFramesQueued - 1)
                 duration += 20;
 
             //Make sure we dont fall behind on big hitches
@@ -243,7 +245,7 @@ public:
             if (!started)
             {
                 //Buffer frames, then start
-                if (framesQueued > MAX_NUM_OUTPUT_FRAMES - 4)
+                if (framesQueued >= minFramesQueued)
                 {
                     // Start
                     result = m_deckLinkOutput->StartScheduledPlayback(0, timeScale, 1.0);
@@ -284,6 +286,11 @@ public:
             }
         }
 
+    }
+
+    void SetLowLatencyMode(bool isEnabled)
+    {
+        minFramesQueued = isEnabled ? 1 : defaultMinFramesQueued;
     }
 
     HRESULT	STDMETHODCALLTYPE ScheduledFrameCompleted(IDeckLinkVideoFrame* completedFrame, BMDOutputFrameCompletionResult result)
@@ -735,6 +742,10 @@ int DeckLinkDevice::GetNumQueuedOutputFrames()
     return s_outputScheduler.framesQueued;
 }
 
+void DeckLinkDevice::SetOutputLowLatencyMode(bool isEnabled)
+{
+    s_outputScheduler.SetLowLatencyMode(isEnabled);
+}
 
 void DeckLinkDevice::Update(int compositeFrameIndex)
 {

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.cpp
@@ -290,7 +290,7 @@ public:
 
     void SetLatencyPreference(float latencyPreference)
     {
-        minFramesQueued = 1 + latencyPreference * (minFramesQueued - 1);
+        minFramesQueued = 1 + latencyPreference * (defaultMinFramesQueued - 1);
         minFramesQueued = min(1UL, max(minFramesQueued, static_cast<unsigned long>(MAX_NUM_OUTPUT_FRAMES)));
     }
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
@@ -139,6 +139,7 @@ public:
     }
 
     int GetNumQueuedOutputFrames();
+    void SetOutputLowLatencyMode(bool isEnabled);
 
     bool ProvidesYUV();
     bool ExpectsYUV();

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkDevice.h
@@ -139,7 +139,7 @@ public:
     }
 
     int GetNumQueuedOutputFrames();
-    void SetOutputLowLatencyMode(bool isEnabled);
+    void SetLatencyPreference(float latencyPreference);
 
     bool ProvidesYUV();
     bool ExpectsYUV();

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
@@ -181,7 +181,13 @@ int DeckLinkManager::GetNumQueuedOutputFrames()
     return 0;
 }
 
-
+void DeckLinkManager::SetOutputLowLatencyMode(bool isEnabled)
+{
+    if (IsEnabled())
+    {
+        deckLinkDevice->SetOutputLowLatencyMode(isEnabled);
+    }
+}
 
 bool DeckLinkManager::IsEnabled()
 {

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.cpp
@@ -181,11 +181,11 @@ int DeckLinkManager::GetNumQueuedOutputFrames()
     return 0;
 }
 
-void DeckLinkManager::SetOutputLowLatencyMode(bool isEnabled)
+void DeckLinkManager::SetLatencyPreference(float latencyPreference)
 {
     if (IsEnabled())
     {
-        deckLinkDevice->SetOutputLowLatencyMode(isEnabled);
+        deckLinkDevice->SetLatencyPreference(latencyPreference);
     }
 }
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
@@ -24,6 +24,7 @@ public:
     int GetCaptureFrameIndex();
     int GetPixelChange(int frame);
     int GetNumQueuedOutputFrames();
+    void SetOutputLowLatencyMode(bool isEnabled);
 
     void Update(int compositeFrameIndex);
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/DeckLinkManager.h
@@ -24,7 +24,7 @@ public:
     int GetCaptureFrameIndex();
     int GetPixelChange(int frame);
     int GetNumQueuedOutputFrames();
-    void SetOutputLowLatencyMode(bool isEnabled);
+    void SetLatencyPreference(float latencyPreference);
 
     void Update(int compositeFrameIndex);
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
@@ -53,6 +53,7 @@ public:
     virtual int GetCaptureFrameIndex() { return 0; }
     virtual int GetPixelChange(int frame) { return 0; }
     virtual int GetNumQueuedOutputFrames() { return 0; }
+    virtual void SetOutputLowLatencyMode(bool isEnabled) {}
     virtual bool IsCameraCalibrationInformationAvailable() { return false; }
     virtual void GetCameraCalibrationInformation(CameraIntrinsics* calibration) {}
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/IFrameProvider.h
@@ -53,7 +53,7 @@ public:
     virtual int GetCaptureFrameIndex() { return 0; }
     virtual int GetPixelChange(int frame) { return 0; }
     virtual int GetNumQueuedOutputFrames() { return 0; }
-    virtual void SetOutputLowLatencyMode(bool isEnabled) {}
+    virtual void SetLatencyPreference(float latencyPreference) {}
     virtual bool IsCameraCalibrationInformationAvailable() { return false; }
     virtual void GetCameraCalibrationInformation(CameraIntrinsics* calibration) {}
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -308,11 +308,11 @@ UNITYDLL int GetNumQueuedOutputFrames()
     return 0;
 }
 
-UNITYDLL void SetOutputLowLatencyMode(bool isEnabled)
+UNITYDLL void SetLatencyPreference(float latencyPreference)
 {
     if (ci != nullptr)
     {
-        ci->SetOutputLowLatencyMode(isEnabled);
+        ci->SetLatencyPreference(latencyPreference);
     }
 }
 

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -308,6 +308,14 @@ UNITYDLL int GetNumQueuedOutputFrames()
     return 0;
 }
 
+UNITYDLL void SetOutputLowLatencyMode(bool isEnabled)
+{
+    if (ci != nullptr)
+    {
+        ci->SetOutputLowLatencyMode(isEnabled);
+    }
+}
+
 UNITYDLL void SetCompositeFrameIndex(int index)
 {
     if (ci != nullptr)

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -184,6 +184,13 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
 
                             compositionManager.OutputDevice = supportedOutputDevices[selectedIndex];
 
+                            EditorGUILayout.EndHorizontal();
+                            EditorGUILayout.Space();
+                            EditorGUILayout.BeginHorizontal();
+
+                            var lowLatencyLabel = new GUIContent("Low Latency Mode", "Disables buffers to prevent stutters on performance or IO problems. Enable only for live production.");
+                            compositionManager.LowLatencyMode = EditorGUILayout.Toggle(lowLatencyLabel, compositionManager.LowLatencyMode);
+
                             if ((supportedCaptureDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_NFOV && supportedCaptureDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_WFOV) || compositionManager.VideoRecordingLayout == VideoRecordingFrameLayout.Quad)
                             {
                                 GUI.enabled = false;

--- a/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView.Editor/Scripts/CompositorWindow.cs
@@ -182,14 +182,7 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                                 .Select(x => x.ToString())
                                 .ToArray());
 
-                            compositionManager.OutputDevice = supportedOutputDevices[selectedIndex];
-
-                            EditorGUILayout.EndHorizontal();
-                            EditorGUILayout.Space();
-                            EditorGUILayout.BeginHorizontal();
-
-                            var lowLatencyLabel = new GUIContent("Low Latency Mode", "Disables buffers to prevent stutters on performance or IO problems. Enable only for live production.");
-                            compositionManager.LowLatencyMode = EditorGUILayout.Toggle(lowLatencyLabel, compositionManager.LowLatencyMode);
+                            compositionManager.OutputDevice = supportedOutputDevices[selectedIndex];                            
 
                             if ((supportedCaptureDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_NFOV && supportedCaptureDevices[selectedIndex] != FrameProviderDeviceType.AzureKinect_DepthCamera_WFOV) || compositionManager.VideoRecordingLayout == VideoRecordingFrameLayout.Quad)
                             {
@@ -548,6 +541,9 @@ namespace Microsoft.MixedReality.SpectatorView.Editor
                     }
 
                     EditorGUILayout.Space();
+
+                    var lowLatencyLabel = new GUIContent("Latency Preference", "Higher values improve resilience against stutters, lower values improve latency.");
+                    compositionManager.LatencyPreference = EditorGUILayout.Slider(lowLatencyLabel, compositionManager.LatencyPreference, 0.0f, 1.0f);
                 }
                 EditorGUILayout.EndVertical();
             }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -18,6 +18,13 @@ namespace Microsoft.MixedReality.SpectatorView
         private const int DSPBufferSize = 1024;
         private const AudioSpeakerMode SpeakerMode = AudioSpeakerMode.Stereo;
 
+        private static class InputFrameStep
+        {
+            public const int DefaultMinimum = 8;
+            public const int LowLatencyMinimum = 2;
+            public const int Maximum = 16;
+        }
+
         public enum Depth { None, Sixteen = 16, TwentyFour = 24 }
         public enum AntiAliasingSamples { One = 1, Two = 2, Four = 4, Eight = 8 };
 
@@ -526,13 +533,13 @@ namespace Microsoft.MixedReality.SpectatorView
 
             //Set our current frame towards the latest captured frame. Dont get too close to it, and dont fall too far behind 
             int step = (captureFrameIndex - CurrentCompositeFrame);
-            if (step < (LowLatencyMode ? 2 : 8))
+            if (step < (LowLatencyMode ? InputFrameStep.LowLatencyMinimum : InputFrameStep.DefaultMinimum))
             {
                 step = 0;
             }
-            else if (step > 16)
+            else if (step > InputFrameStep.Maximum)
             {
-                step -= 16;
+                step -= InputFrameStep.Maximum;
             }
             else
             {

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -83,6 +83,7 @@ namespace Microsoft.MixedReality.SpectatorView
         private int outputDeviceIndex = -1;
         private int videoRecordingLayout = -1;
         private int occlusionMode = -1;
+        private bool? lowLatencyMode = null;
         private TextureManager textureManager = null;
         private MicrophoneInput microphoneInput;
 
@@ -253,6 +254,27 @@ namespace Microsoft.MixedReality.SpectatorView
                 {
                     occlusionMode = (int)value;
                     PlayerPrefs.SetInt(nameof(OcclusionMode), occlusionMode);
+                    PlayerPrefs.Save();
+                }
+            }
+        }
+
+        public bool LowLatencyMode
+        {
+            get
+            {
+                if (lowLatencyMode == null)
+                {
+                    lowLatencyMode = PlayerPrefs.GetInt(nameof(LowLatencyMode), 0) != 0;
+                }
+                return lowLatencyMode.Value;
+            }
+            set
+            {
+                if (lowLatencyMode != value)
+                {
+                    lowLatencyMode = value;
+                    PlayerPrefs.SetInt(nameof(LowLatencyMode), value ? 1 : 0);
                     PlayerPrefs.Save();
                 }
             }
@@ -504,7 +526,7 @@ namespace Microsoft.MixedReality.SpectatorView
 
             //Set our current frame towards the latest captured frame. Dont get too close to it, and dont fall too far behind 
             int step = (captureFrameIndex - CurrentCompositeFrame);
-            if (step < 8)
+            if (step < (LowLatencyMode ? 2 : 8))
             {
                 step = 0;
             }
@@ -577,6 +599,7 @@ namespace Microsoft.MixedReality.SpectatorView
                             stationaryCameraBroadcaster.SetActive(true);
                             HolographicCameraObserver.Instance.ConnectTo("127.0.0.1");
                         }
+                        UnityCompositorInterface.SetOutputLowLatencyMode(LowLatencyMode);
                     }
                 }
                 else

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
@@ -188,6 +188,9 @@ namespace Microsoft.MixedReality.SpectatorView
         public static extern int GetNumQueuedOutputFrames();
 
         [DllImport(CompositorPluginDll)]
+        public static extern void SetOutputLowLatencyMode(bool isEnabled);
+
+        [DllImport(CompositorPluginDll)]
         public static extern IntPtr GetRenderEventFunc();
 
         [DllImport(CompositorPluginDll)]

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/UnityCompositorInterface.cs
@@ -188,7 +188,7 @@ namespace Microsoft.MixedReality.SpectatorView
         public static extern int GetNumQueuedOutputFrames();
 
         [DllImport(CompositorPluginDll)]
-        public static extern void SetOutputLowLatencyMode(bool isEnabled);
+        public static extern void SetLatencyPreference(float latencyPreference);
 
         [DllImport(CompositorPluginDll)]
         public static extern IntPtr GetRenderEventFunc();


### PR DESCRIPTION
## Description

My team is exploring the usage of Steadycams for being mobile whilst using heavier production cameras, as these are difficult to carry around and move smoothly for the duration of the shoot. In this scenario the monitor on the rig can provider the operator with a live view with the holograms to be able to frame them properly.
The buffering of frames works great for smooth recordings but also introduces quite a bit of latency on top of the necessary technical latency by transmitting the video signal from and back to the camera rig. This PR adds a low-latency mode switch which reduces both the buffering done in the input ([`CompositionManager.cs:507`](https://github.com/microsoft/MixedReality-SpectatorView/pull/381/files#diff-a831c0726943bca9148b344f03d11ffbL507)) and in the DeskLink Output ([`DeckLinkDevice.cpp:246`](https://github.com/microsoft/MixedReality-SpectatorView/pull/381/files#diff-0c30655b993435b2c4d00acb52bfb693L246)).

In a simple test of using a stopwatch to measure the perceived latency between a visual change in front of the camera to it being seen on the rig monitor this achieves a drop from ~1,1 seconds down to ~0,4 seconds. Which still isn't great but a necessary improvement for these types of rigs.

## Summary of Changes

- A new property `CompositionManager.LowLatencyMode` which is used for initialization and for stepping forward in the input frames.
- To toggle this the `CompositorWindow` UI has been adapted
- A new frame provider method `SetOutputLowLatencyMode` is propagated through all the layers of the native compositor
- The `OutputScheduler` of the decklink frame provider uses a configurable limit to judge the health of the output queue