### PR TITLE
Fix HolographicCamera build

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -284,10 +284,12 @@ namespace Microsoft.MixedReality.SpectatorView
                     PlayerPrefs.SetFloat(nameof(LatencyPreference), latencyPreference);
                     PlayerPrefs.Save();
 
+#if UNITY_EDITOR
                     if (IsVideoFrameProviderInitialized)
                     {
                         UnityCompositorInterface.SetLatencyPreference(latencyPreference);
                     }
+#endif
                 }
             }
         }


### PR DESCRIPTION
I am afraid that with #381 I broke at least the HolographicCamera build as `UnityCompositorInterface` is only defined for the editor whilst `CompositionManager` is compiled for all platforms. A quick macro-if fixes the build.