### PR TITLE
Improving Videoencoder

### DIFF
--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.cpp
@@ -386,10 +386,20 @@ void CompositorInterface::StopRecording()
     activeVideoEncoder = nullptr;
 }
 
-void CompositorInterface::RecordFrameAsync(BYTE* videoFrame, LONGLONG frameTime, int numFrames)
+std::unique_ptr<VideoEncoder::VideoInput> CompositorInterface::GetAvailableRecordFrame()
+{
+    if (activeVideoEncoder == nullptr)
+    {
+        OutputDebugString(L"GetAvailableRecordFrame dropped, no active encoder\n");
+        return nullptr;
+    }
+    return activeVideoEncoder->GetAvailableVideoFrame();
+}
+
+void CompositorInterface::RecordFrameAsync(std::unique_ptr<VideoEncoder::VideoInput> frame, int numFrames)
 {
 #if _DEBUG
-	std::wstring debugString = L"RecordFrameAsync called, frameTime:" + std::to_wstring(frameTime) + L", numFrames:" + std::to_wstring(numFrames) + L"\n";
+	std::wstring debugString = L"RecordFrameAsync called, frameTime:" + std::to_wstring(frame->timestamp) + L", numFrames:" + std::to_wstring(numFrames) + L"\n";
 	OutputDebugString(debugString.data());
 #endif
 
@@ -407,8 +417,8 @@ void CompositorInterface::RecordFrameAsync(BYTE* videoFrame, LONGLONG frameTime,
 	// The encoder will update sample times internally based on the first seen sample time when recording.
 	// The encoder, however, does assume that audio and video samples will be based on the same source time.
 	// Providing audio and video samples with different starting times will cause issues in the generated video file.
-	LONGLONG sampleTime = frameTime;
-    activeVideoEncoder->QueueVideoFrame(videoFrame, sampleTime, numFrames * frameProvider->GetDurationHNS());
+    frame->duration = numFrames * frameProvider->GetDurationHNS();
+    activeVideoEncoder->QueueVideoFrame(std::move(frame));
 }
 
 void CompositorInterface::RecordAudioFrameAsync(BYTE* audioFrame, LONGLONG audioTime, int audioSize)

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/CompositorInterface.h
@@ -80,7 +80,8 @@ public:
     DLLEXPORT void StopRecording();
     
 	// frameTime is in hundred nano seconds
-	DLLEXPORT void RecordFrameAsync(BYTE* videoFrame, LONGLONG frameTime, int numFrames);
+    DLLEXPORT std::unique_ptr<VideoEncoder::VideoInput> GetAvailableRecordFrame();
+	DLLEXPORT void RecordFrameAsync(std::unique_ptr<VideoEncoder::VideoInput>, int numFrames);
 
 	// audioTime is in hundrend nano seconds
     DLLEXPORT void RecordAudioFrameAsync(BYTE* audioFrame, LONGLONG audioTime, int audioSize);

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp
@@ -347,8 +347,12 @@ void VideoEncoder::WriteVideo(std::unique_ptr<VideoEncoder::VideoInput> frame)
 #endif
     }
 
-    std::async(std::launch::async, [=, frame{ std::move(frame) }]() mutable
+    videoWriteFuture = std::async(std::launch::async, [=, frame{ std::move(frame) }, previousWriteFuture{ std::move(videoWriteFuture) }]() mutable
     {
+        if (previousWriteFuture.valid())
+        {
+            previousWriteFuture.wait();
+        }
         std::shared_lock<std::shared_mutex> lock(videoStateLock);
 
         HRESULT hr = E_PENDING;

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h
@@ -119,6 +119,7 @@ private:
 
     std::shared_mutex videoStateLock;
     std::shared_mutex videoInputPoolLock;
+    std::future<void> videoWriteFuture;
 
 #if HARDWARE_ENCODE_VIDEO
     IMFDXGIDeviceManager* deviceManager = NULL;

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h
@@ -197,6 +197,7 @@ private:
     std::future<void> videoWriteFuture;
 
 #if HARDWARE_ENCODE_VIDEO
+    ID3D11Device* device;
     IMFDXGIDeviceManager* deviceManager = NULL;
     UINT resetToken = 0;
 #endif

--- a/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h
@@ -48,19 +48,38 @@ public:
 
     class VideoInput
     {
+        byte* buffer = nullptr;
     public:
         VideoInput(size_t bufferSize)
         {
-            buffer = new byte[bufferSize];
+            auto hr = MFCreateMemoryBuffer(bufferSize, &mediaBuffer);
         }
 
         ~VideoInput()
         {
-            delete[] buffer;
+            Unlock();
+            SafeRelease(mediaBuffer);
         }
 
-        byte* buffer;
+        byte* Lock()
+        {
+            if (buffer == nullptr)
+            {
+                mediaBuffer->Lock(&buffer, NULL, NULL);
+            }
+            return buffer;
+        }
 
+        void Unlock()
+        {
+            if (buffer != nullptr)
+            {
+                mediaBuffer->Unlock();
+                buffer = nullptr;
+            }
+        }
+
+        IMFMediaBuffer* mediaBuffer = nullptr;
         LONGLONG timestamp = INVALID_TIMESTAMP;
         LONGLONG duration = INVALID_TIMESTAMP;
     };

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -178,8 +178,10 @@ void UpdateVideoRecordingFrame()
         float bpp = FRAME_BPP_RGBA;
 #endif
 
-        VideoTextureBuffer.FetchTextureData(g_pD3D11Device, videoBytes[videoBufferIndex], bpp);
-        ci->RecordFrameAsync(videoBytes[videoBufferIndex], queuedVideoFrameTime, queuedVideoFrameCount);
+        auto frame = ci->GetAvailableRecordFrame();
+        VideoTextureBuffer.FetchTextureData(g_pD3D11Device, frame->buffer, bpp);
+        frame->timestamp = queuedVideoFrameTime;
+        ci->RecordFrameAsync(std::move(frame), queuedVideoFrameCount);
     }
 
     if (lastVideoFrame >= 0 && lastRecordedVideoFrame != lastVideoFrame)

--- a/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
+++ b/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp
@@ -128,7 +128,7 @@ void UpdateVideoRecordingFrame()
 #endif
 
         auto frame = ci->GetAvailableRecordFrame();
-        VideoTextureBuffer.FetchTextureData(g_pD3D11Device, frame->buffer, bpp);
+        VideoTextureBuffer.FetchTextureData(g_pD3D11Device, frame->Lock(), bpp);
         frame->timestamp = queuedVideoFrameTime;
         ci->RecordFrameAsync(std::move(frame), queuedVideoFrameCount);
     }

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/Compositor/TextureManager.cs
@@ -565,7 +565,8 @@ namespace Microsoft.MixedReality.SpectatorView
                 }
 
                 // convert composite to the format expected by our video encoder (NV12 or BGR)
-                Graphics.Blit(videoSourceTexture, videoOutputTexture, hardwareEncodeVideo ? NV12VideoMat : BGRVideoMat);
+                //Graphics.Blit(videoSourceTexture, videoOutputTexture, hardwareEncodeVideo ? NV12VideoMat : BGRVideoMat);
+                Graphics.Blit(videoSourceTexture, videoOutputTexture, BGRVideoMat);
             }
 
             TextureRenderCompleted?.Invoke();
@@ -613,7 +614,7 @@ namespace Microsoft.MixedReality.SpectatorView
             RGBToYUVMat.SetFloat("_Width", frameWidth);
             RGBToYUVMat.SetFloat("_Height", frameHeight);
 
-            BGRVideoMat.SetFloat("_YFlip", 0);
+            BGRVideoMat.SetFloat("_YFlip", 1);
         }
 
         /// <summary>


### PR DESCRIPTION
So after a couple of shooting days we had some issues with the resulting footage, namely some stutters by duplicated frames and what seemed like frames starting and ending at wrong times relative to the video (video pausing for up to several minutes at starting and freezing at the end). This is why I tried looking into improving the videoencoder a bit, ideally lowering the required CPU usage especially for split channels as these are very high leaving not much room for the application itself (jumping from ~ca 30% to 70-80% on a modern 6-core CPU).

I found a couple of things but as some of these changes are a bit bigger I would like to check with you whether you are OK with the proposed API changes or if you have further insights which I missed. Also I am sorry in beforehand for the long text, I deemed it necessary to explain the complexity involved.

## Current Changes

### Unnecessary Memory allocations/copies
With the current state of master a rendered frame takes this way to the `IMFSinkWriter`: 
- Fetched from GPU into a (unguarded) ring of 10 buffers owned by UnityCompositorInterface ([UnityCompositorInterface.cpp:181](https://github.com/microsoft/MixedReality-SpectatorView/blob/7796da6acb0ae41bed1b9e0e9d1c5c683b4b8374/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp#L181))
- Copied into a newly allocated temporary buffer owned by the current videoencoder ([VideoEncoder.cpp:346](https://github.com/microsoft/MixedReality-SpectatorView/blob/7796da6acb0ae41bed1b9e0e9d1c5c683b4b8374/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L346))
- Copied into another newly allocated `IMFMediaBuffer` owned by the `WriteVideo` task ([VideoEncoder.cpp:387](https://github.com/microsoft/MixedReality-SpectatorView/blob/7796da6acb0ae41bed1b9e0e9d1c5c683b4b8374/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L387))
- (Presumably) uploaded to GPU for hardware encoding; alternatively processed directly by the CPU 

These copies as far as I can see are done for buffering (multiple render events for one `UpdateCompositor` call), multithreading (so the `WriteVideo` task does not access the ring pool) and maybe encapsulation (so the UnityCompositorInterface does not have to know about Media Foundation)? I drafted an alternative method to deal with these intentions without copies although with a bit looser encapsulation, based on move semantics. So (for CPU encoding) the new flow would look like this (probably best explored at 9cc0fbb):

- at initialization the videoencoder allocates a pool of 10 frame buffers ([VideoEncoder.cpp:66](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L66))
- The UnityCompositorInterface gets a new frame buffer (by `std::unique_ptr`) from the videoencoder ([UnityCompositorInterface.cpp:125](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp#L125))
- these frames own an lockable `IMFMediaBuffer` in which the texture is fetched ([VideoEncoder.h:127](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h#L127))
- the UnityCompositorInterface moves the frame back to the videoencoder with `QueueVideoFrame` ([UnityCompositorInterface.cpp:128](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/UnityPlugin/UnityCompositorInterface.cpp#L128))
- the videoencoder calculates the right sample time and moves the frame into the asynchronous task of `WriteVideo` ([VideoEncoder.cpp:366](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L366))
- when the task finishes it moves the frame back into the pool ([VideoEncoder.cpp:411](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L411))

This way the fetched frame is never copied (at least not by the SpectatorView) around in memory and no temporary memory is allocated and freed per frame. The biggest caveat for me with this would be the exposing of `IMFMediaBuffer` although the UnityCompositorInterface does not have to interact with it.

For implementation I had to replace the usage of the `concurrency::create_task` from the PPL, also I could not use `concurrency::concurrent_queue` for the frame pool as the PPL does not seem to support move-only datatypes. Luckily there is a standard c++ functionality for the `create_task` (`std::async` with the `std::launch::async` policy set) and a simple pair of `std::queue` and `std::mutex` for the pool.

### Potentially unordered `WriteSample` calls

As far as I understood multiple `concurrency::create_task` calls are not guaranteed to be called in order? This would mean that samples could be written out of order and we would rely on the implementation of the MFT to deal with sorting the frames. Also as the completion of the tasks are never waited for there could `WriteSample` calls still queued while the `Finalize` call for the `sinkWriter` is executed.

By using `std::async` we get a `std::future` one can wait for to ensure that frames are written in order ([VideoEncoder.cpp:370](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L370)) and that all frames are written before finalizing ([VideoEncoder.cpp:449](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L449)).

### (Actual) hardware encoding

While trying to transfer the video texture directly to the video encoder without fetching its contents I stumbled upon [this line](https://github.com/microsoft/MixedReality-SpectatorView/blob/7796da6acb0ae41bed1b9e0e9d1c5c683b4b8374/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L75). It seems to me like by setting the result to an error code the attributes responsible for hardware encoding (and disabling throttling, lines 92-96) are never set? So mediafoundation could have chosen a software encoder all along.

### Encoding the video texture directly

As already stated by a TODO comment it would be great to encode the rendered video texture directly without temporarily fetching its content to RAM and back uploading back to GPU. Unfortunately this is a bit easier said than done.

Getting the textures to the video encoder is still easy enough, the texture should be copied into temporary one so the original can be modified while the older ones are encoded. The `VideoInput` class for hardware encoding needs a reference to the `ID3D11Device` though to create the texture (to not restrict the texture format of the input) and to trigger the GPU texture copy. The corresponding `IMFMediaBuffer` is created with `MFCreateDXGISurfaceBuffer` ([VideoEncoder.h:97](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.h#L97)) which is then passed to the `sinkWriter` as normal.

In order to prepare the `sinkWriter` to accept textures it needs synchronized access to the `ID3D11Device` for which a `IMFDXGIDeviceManager` is required which needs to be set as attribute ([VideoEncoder.cpp:115](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L115)). This manager was already created in the code but not passed. Also I think it is supposed to be used to synchronize the access to the device for the entire application? Which is not possible as we cannot control Unity's usage of the device. For an easy and working solution I opted to just move the synchronization to DirectX itself by using `ID3D10Multithread` ([VideoEncoder.cpp:61](https://github.com/hermann-noll/MixedReality-SpectatorView/blob/09f62de01c1419c20dd7e1a1b1ea3ce47f4db7b2/src/SpectatorView.Native/SpectatorView.Compositor/Compositor/VideoEncoder.cpp#L61)) but I guess a cleaner way would be to create a new headless `ID3D11Device` and use shared textures?

Also I could not get the encoding to work with the NV12 conversion, as `WriteSample` would return `MF_E_BUFFERTOOSMALL`. My guess would be that despite setting every input buffer and stating every buffer size as being  stride=4 (as RGBA), the encoder would try to internally copy the entire texture (which still is stride=4 after conversion) into a internally allocated buffer with stride=2 for NV12.

## Changes left to do (and not yet discussed)

### Wrong sample time calculation?
I did not yet tackle the problem of some videos starting or ending with long freezes, I think the first one can be replicated by recording twice for a bit without leaving the play mode in between.

### Color conversions
I would guess that the RGB->NV12 conversion is not needed for hardware encoding anymore but would accelerate the CPU encoding (so turning the current logic around). The current state of this PR is that this conversion is disabled for all (with uncleaned parts still lying around)

### Audio side
Similar changes (especially the frame moving) can be applied to the audio side of the video encoder as well, but I wanted to discuss the more complex (and more performance-heavy) video changes with you first.
