### PR TITLE
DRAFT: broadcast a dynamically-generated mesh

### DIFF
--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/AssetService.cs
@@ -103,6 +103,14 @@ namespace Microsoft.MixedReality.SpectatorView
             return false;
         }
 
+        public bool AttachDynamicMeshFilter(GameObject gameObject, AssetId assetId, Mesh mesh)
+        {
+            ComponentExtensions.EnsureComponent<MeshRenderer>(gameObject);
+            MeshFilter filter = ComponentExtensions.EnsureComponent<MeshFilter>(gameObject);
+            filter.sharedMesh = mesh;
+            return true;
+        }
+
         public bool AttachSkinnedMeshRenderer(GameObject gameObject, AssetId assetId)
         {
             Mesh mesh = meshAssets.GetAsset(assetId);

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterBroadcaster.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterBroadcaster.cs
@@ -9,6 +9,10 @@ namespace Microsoft.MixedReality.SpectatorView
 {
     internal class MeshFilterBroadcaster : MeshRendererBroadcaster<MeshFilterService>
     {
+        // A unique integer value used to check that mesh data is correctly written and read.
+        // TODO: After some time, if this is working reliably, this check could be removed.
+        public const int CheckValue = 123454321;
+
         public static class MeshFilterChangeType
         {
             public const byte Mesh = 0x8;
@@ -27,9 +31,40 @@ namespace Microsoft.MixedReality.SpectatorView
             if (HasFlag(changeType, MeshFilterChangeType.Mesh))
             {
                 message.Write(assetId);
+
+                if (assetId == AssetId.Empty)
+                {
+                    // This is a dynamic object that wasn't created from an asset.
+                    bool hasDynamicMesh = meshFilter.sharedMesh != null;
+                    message.Write(hasDynamicMesh);
+                    if (hasDynamicMesh)
+                    {
+                        WriteDynamicMesh(message, meshFilter.sharedMesh);
+                    }
+                }
             }
 
             base.WriteRenderer(message, changeType);
+        }
+
+        private void WriteDynamicMesh(BinaryWriter message, Mesh mesh)
+        {
+            message.Write(CheckValue);
+            message.Write(mesh.subMeshCount);
+            message.Write(mesh.vertices);
+            message.Write(mesh.uv);
+            message.Write(mesh.uv2);
+            message.Write(mesh.uv3);
+            message.Write(mesh.uv4);
+            message.Write(mesh.uv5);
+            message.Write(mesh.uv6);
+            message.Write(mesh.uv7);
+            message.Write(mesh.uv8);
+            message.Write(mesh.colors);
+            message.Write(mesh.triangles);
+            message.Write(CheckValue);
+
+            Debug.Log($"MeshFilterBroadcaster.WriteDynamicMesh: {gameObject.name} written with {mesh.subMeshCount} subMeshCount, {mesh.vertices?.Length} vertices, {mesh.triangles?.Length} triangles");
         }
 
         protected override void OnInitialized()

--- a/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterObserver.cs
+++ b/src/SpectatorView.Unity/Assets/SpectatorView/Scripts/StateSynchronization/NetworkedComponents/MeshFilter/MeshFilterObserver.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.SpectatorView
 {
@@ -13,10 +14,55 @@ namespace Microsoft.MixedReality.SpectatorView
             if (MeshFilterBroadcaster.HasFlag(changeType, MeshFilterBroadcaster.MeshFilterChangeType.Mesh))
             {
                 AssetId assetId = message.ReadAssetId();
-                AssetService.Instance.AttachMeshFilter(this.gameObject, assetId);
+                if (assetId != AssetId.Empty)
+                {
+                    AssetService.Instance.AttachMeshFilter(this.gameObject, assetId);
+                }
+                else
+                {
+                    bool hasDynamicMesh = message.ReadBoolean();
+                    if (hasDynamicMesh)
+                    {
+                        Mesh mesh = ReadDynamicMesh(message);
+                        AssetService.Instance.AttachDynamicMeshFilter(this.gameObject, assetId, mesh);
+                    }
+                }
             }
 
             base.EnsureRenderer(message, changeType);
+        }
+
+        private Mesh ReadDynamicMesh(BinaryReader message)
+        {
+            int checkValue = message.ReadInt32();
+            if (checkValue != MeshFilterBroadcaster.CheckValue)
+            {
+                Debug.LogError($"MeshFilterObserver.ReadDynamicMesh: {gameObject.name} initial checkValue mismatch! All subsequent spectator view data will read incorrectly!");
+            }
+
+            Mesh mesh = new Mesh();
+            mesh.subMeshCount = message.ReadInt32();
+            mesh.vertices = message.ReadVector3Array();
+            mesh.uv = message.ReadVector2Array();
+            mesh.uv2 = message.ReadVector2Array();
+            mesh.uv3 = message.ReadVector2Array();
+            mesh.uv4 = message.ReadVector2Array();
+            mesh.uv5 = message.ReadVector2Array();
+            mesh.uv6 = message.ReadVector2Array();
+            mesh.uv7 = message.ReadVector2Array();
+            mesh.uv8 = message.ReadVector2Array();
+            mesh.colors = message.ReadColorArray();
+            mesh.triangles = message.ReadInt32Array();
+            mesh.RecalculateNormals();
+
+            checkValue = message.ReadInt32();
+            if (checkValue != MeshFilterBroadcaster.CheckValue)
+            {
+                Debug.LogError($"MeshFilterObserver.ReadDynamicMesh: {gameObject.name} final checkValue mismatch! All subsequent spectator view data will read incorrectly!");
+            }
+
+            Debug.Log($"MeshFilterObserver.ReadDynamicMesh: {gameObject.name} read with {mesh.subMeshCount} subMeshCount, {mesh.vertices?.Length} vertices, {mesh.triangles?.Length} triangles");
+            return mesh;
         }
     }
 }


### PR DESCRIPTION
This is code that we used in a particular project that I'm sharing here for reference. There might be aspects that should be more generalized before this is made a standard SpectatorView feature, but I don't have time to develop it further.

Potential issues include:
* Hasn't been tested with the latest code in this repository.
* I believe there are warnings about dynamic meshes elsewhere in the system that should be removed once dynamic meshes are supported.
* Should have a test case or example content demonstrating that it works.
* Contains an unnecessary CheckValue and logging that should probably be removed.
* Transmits a dynamically-generated mesh, but doesn't detect dynamic changes to that mesh. Optionally, dynamically-changing meshes could be supported with a checksum of the mesh data.